### PR TITLE
fix(tunnel,session): self-healing tunnel; no more fleet duplication after a lapsed cookie

### DIFF
--- a/server/src/auth.js
+++ b/server/src/auth.js
@@ -13,6 +13,12 @@ const os = require('os');
 
 const COOKIE_NAME = 'soa_web_auth';
 const COOKIE_MAX_AGE_SEC = 60 * 60 * 24 * 7;  // 7 days
+// Re-issue a cookie once it is this old. Without a sliding window an active
+// browser crosses the hard Max-Age mid-session: its next request mints a NEW,
+// empty session, and the WS bind that follows can rehydrate the saved fleet on
+// top of the one still running (2026-08-25: 7-day cookie lapsed at 17:31, the
+// phone bound to the fresh empty session at 21:10, every agent got doubled).
+const COOKIE_RENEW_AFTER_MS = 60 * 60 * 24 * 1000;
 
 const SIGN_KEY_FILE = require('./stateDir').stateFile('sign-key');
 
@@ -53,6 +59,21 @@ function verify(signed, key) {
 function issue(subject, key) {
     const payload = JSON.stringify({ sub: subject, iat: Date.now() });
     return sign(Buffer.from(payload).toString('base64url'), key);
+}
+
+// iat (ms) baked into a signed cookie, or null when it doesn't verify.
+function issuedAt(signedCookie, key) {
+    const decoded = verify(signedCookie, key);
+    if (!decoded) return null;
+    try {
+        const iat = JSON.parse(Buffer.from(decoded, 'base64url').toString('utf8')).iat;
+        return Number.isFinite(iat) ? iat : null;
+    } catch (_) { return null; }
+}
+
+function shouldRenew(iatMs, nowMs = Date.now()) {
+    if (!Number.isFinite(iatMs)) return true;
+    return nowMs - iatMs >= COOKIE_RENEW_AFTER_MS;
 }
 
 function readCookie(header, name) {
@@ -103,6 +124,7 @@ function constantTimeEq(a, b) {
 }
 
 module.exports = {
+    issuedAt, shouldRenew, COOKIE_RENEW_AFTER_MS,
     COOKIE_NAME,
     resolveSignKey,
     sign, verify, issue,

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -257,6 +257,15 @@ function currentSession(req) {
 // keeps them on the same one across reloads.
 function requireAuthed(req, res, next) {
     let s = currentSession(req);
+    // Sliding expiry: re-issue a cookie older than a day so an active browser
+    // never crosses the hard Max-Age. Crossing it silently re-provisions the
+    // browser onto a fresh EMPTY session (see auth.COOKIE_RENEW_AFTER_MS).
+    if (s) {
+        const raw = auth.readCookie(req.headers.cookie || '', auth.COOKIE_NAME);
+        if (raw && auth.shouldRenew(auth.issuedAt(raw, SIGN_KEY))) {
+            res.setHeader('Set-Cookie', auth.makeCookie(auth.issue(s.token, SIGN_KEY), { secure: SECURE_COOKIE, crossSite: CROSS_SITE }));
+        }
+    }
     // Pairing-token attach: a request carrying a valid per-session token (?t= or
     // Bearer) binds to that session even with no cookie — this is how a phone
     // that scanned the QR authenticates. Mint the cookie so its later
@@ -626,8 +635,10 @@ server.on('upgrade', (req, socket, head) => {
     // divergence. Only a session that already has tabs is trusted over primary.
     const existingHasTabs = existing && existing.tabMgr && existing.tabMgr.order.length > 0;
     const isLocal = sessionManager.isLocalRequest(req);
+    const tokenSessionHasTabs = !!(tokenSession && tokenSession.tabMgr && tokenSession.tabMgr.order.length > 0);
     const decision = tunnelGate.decideWsBind({
-        tokenSession, existingHasTabs, isLocal, openTunnel: OPEN_TUNNEL, sessionTokenMode: !!SESSION_TOKEN,
+        tokenSession, tokenSessionHasTabs, existingHasTabs, isLocal, openTunnel: OPEN_TUNNEL, sessionTokenMode: !!SESSION_TOKEN,
+        primaryExists: !!_findPrimarySession(),
     });
 
     if (decision.action === 'reject') {
@@ -648,8 +659,9 @@ server.on('upgrade', (req, socket, head) => {
         const primary = _findPrimarySession();
         if (primary && primary !== existing) {
             if (existing) dbg('ws-upgrade', 'cookie session', existing.id.slice(0, 8), 'is empty — sharing primary', primary.id.slice(0, 8));
+            if (tokenSession) dbg('ws-upgrade', 'token session', tokenSession.id.slice(0, 8), 'is empty — sharing primary', primary.id.slice(0, 8));
             session = primary;
-            via = existing ? 'primary-over-empty-cookie' : 'primary-share';
+            via = tokenSession ? decision.via : (existing ? 'primary-over-empty-cookie' : 'primary-share');
         } else if (existing) {
             session = existing; via = 'cookie-empty';
         } else {
@@ -790,18 +802,14 @@ function onWsConnect(ws, session, req) {
             const shellEnv = envStore.getEnvForShell();
             const savedSb = tabPersist.loadScrollback();
             const sbList = (savedSb && Array.isArray(savedSb.tabs)) ? savedSb.tabs : [];
-            // Multiset of live cwds: each live tab consumes one matching saved
-            // entry, so projects with several saved tabs still restore fully.
-            const liveByCwd = new Map();
-            for (const id of session.tabMgr.order) {
-                const t = session.tabMgr.tabs.get(id);
-                if (t && t.cwd) liveByCwd.set(t.cwd, (liveByCwd.get(t.cwd) || 0) + 1);
-            }
+            // Live cwd multiset across EVERY session (tabPersist.liveCwdCounts):
+            // a saved tab is re-opened only when no session at all has a live
+            // shell for it. Counting just this session re-launched the whole
+            // running fleet into an empty session on 2026-08-25.
+            const plan = tabPersist.planRestore(saved.tabs, tabPersist.liveCwdCounts(sessions.sessions.values()));
             const restoredTabs = [];
-            let skipped = 0;
-            saved.tabs.forEach((entry, i) => {
-                const have = liveByCwd.get(entry.cwd) || 0;
-                if (have > 0) { liveByCwd.set(entry.cwd, have - 1); skipped++; return; }
+            const skipped = plan.skipped;
+            plan.open.forEach(({ entry, index: i }) => {
                 const cwd = entry.cwd && fs.existsSync(entry.cwd) ? entry.cwd : undefined;
                 const sb = sbList[i];
                 const prior = (sb && sb.cwd === entry.cwd && typeof sb.scrollback === 'string') ? sb.scrollback : '';
@@ -819,7 +827,7 @@ function onWsConnect(ws, session, req) {
                 if (tab && cwd) restoredTabs.push({ tab, cwd });
             });
             console.log(`restore-on-connect: rehydrated ${restoredTabs.length}/${saved.tabs.length} saved tab(s)`
-                + (skipped ? ` (${skipped} already live)` : ''));
+                + (skipped ? ` (${skipped} already live in some session)` : ''));
             // A fresh daemon respawns dead shells, so each tab's Claude
             // conversation is gone unless we resume it. Auto-resume the tabs
             // whose cwd has a recent transcript (SOA_WEB_NO_AUTO_RESUME=1 off).

--- a/server/src/pairing.js
+++ b/server/src/pairing.js
@@ -27,8 +27,15 @@ function lanAddresses(port, proto = 'http') {
 }
 
 class PairingManager {
-    constructor({ port, publicProto = 'http', bindHost = '0.0.0.0' }) {
+    constructor({ port, publicProto = 'http', bindHost = '0.0.0.0', openTunnel: openTunnelImpl = openTunnel, adopt: adoptImpl = adopt, restartDelayMs = 5000 }) {
         this.port = port;
+        this._openTunnel = openTunnelImpl;
+        this._adopt = adoptImpl;
+        this._restartDelayMs = restartDelayMs;
+        this._restartTimer = null;
+        this._stopped = false;    // explicit stop(): never auto-restart
+        this._detached = false;   // shutting down: never auto-restart
+        this.onTunnelUp = null;   // (url) => void — set by mount(); fires on auto-restart too
         this.publicProto = publicProto;
         // Loopback bind → no LAN interface can actually reach the daemon, so
         // advertising interface IPs would hand the phone a connection-refused
@@ -55,13 +62,15 @@ class PairingManager {
 
     async start() {
         if (this.state === 'starting' || this.state === 'online') return this.snapshot();
+        this._stopped = false;
+        this._clearRestart();
         this.state = 'starting';
         this.error = null;
         try {
             // On a machine with no tunnel provider, openTunnel downloads
             // cloudflared first (~20 MB). Live progress lands in the snapshot
             // so the widget's 6s status poll can narrate the one-time setup.
-            this.tunnel = await openTunnel(this.port, p => { this.progress = p; });
+            this.tunnel = await this._openTunnel(this.port, p => { this.progress = p; });
             this.progress = null;
             if (!this.tunnel) {
                 this.state = 'error';
@@ -72,7 +81,7 @@ class PairingManager {
             this.state = 'online';
             this.startedAt = Date.now();
             if ('onDeath' in this.tunnel) {
-                this.tunnel.onDeath = () => this._reset('tunnel exited');
+                this.tunnel.onDeath = () => this._onTunnelDeath();
             }
             return this.snapshot();
         } catch (err) {
@@ -91,13 +100,13 @@ class PairingManager {
         this.state = 'starting';
         this.error = null;
         try {
-            const t = await adopt(this.port);
+            const t = await this._adopt(this.port);
             if (!t) { this.state = 'idle'; return this.snapshot(); }
             this.tunnel = t;
             this.publicUrl = t.url;
             this.state = 'online';
             this.startedAt = Date.now();
-            if ('onDeath' in t) t.onDeath = () => this._reset('tunnel exited');
+            if ('onDeath' in t) t.onDeath = () => this._onTunnelDeath();
             return this.snapshot();
         } catch (err) {
             this.state = 'idle';
@@ -110,16 +119,49 @@ class PairingManager {
     // graceful daemon restart and the next boot can re-adopt it. Used on
     // shutdown; contrast with stop(), which is an explicit user teardown.
     detach() {
+        this._detached = true;
+        this._clearRestart();
         this.tunnel = null;
         this._reset(null);
     }
 
     stop() {
+        this._stopped = true;
+        this._clearRestart();
         if (this.tunnel) {
             try { this.tunnel.close(); } catch (_) {}
         }
         this._reset(null);
         return this.snapshot();
+    }
+
+    // The tunnel process died underneath us (sleep, network loss, edge reset).
+    // Until 2026-08-25 this parked the manager in `error` until a human clicked
+    // START, so the phone's link stayed dead for hours. Now it re-opens the
+    // tunnel by itself after a short delay. Quick tunnels can't keep their URL,
+    // so onTunnelUp lets index.js re-announce and re-allow the new origin.
+    _onTunnelDeath() {
+        // A late exit notice for a tunnel we already stopped/detached is noise.
+        if (this._stopped || this._detached) return;
+        this._reset('tunnel exited — restarting');
+        this._clearRestart();
+        this._restartTimer = setTimeout(() => {
+            this._restartTimer = null;
+            this.start().then(snap => {
+                if (snap.state === 'online' && snap.publicUrl) {
+                    console.log(`SoA-Web tunnel:  ${snap.publicUrl}  (re-opened after the previous tunnel exited)`);
+                    if (typeof this.onTunnelUp === 'function') { try { this.onTunnelUp(snap.publicUrl); } catch (_) {} }
+                } else if (!this._stopped && !this._detached) {
+                    // Provider still down (no network yet?) — keep trying.
+                    this._onTunnelDeath();
+                }
+            }).catch(() => { if (!this._stopped && !this._detached) this._onTunnelDeath(); });
+        }, this._restartDelayMs);
+        if (this._restartTimer.unref) this._restartTimer.unref();
+    }
+
+    _clearRestart() {
+        if (this._restartTimer) { clearTimeout(this._restartTimer); this._restartTimer = null; }
     }
 
     _reset(error) {
@@ -150,6 +192,7 @@ async function toSvg(text, { size = 220 } = {}) {
 }
 
 function mount(app, requireAuthed, pair, { onTunnelUp } = {}) {
+    if (onTunnelUp) pair.onTunnelUp = onTunnelUp;
     // Helper: tag the snapshot with the caller's session token so the desktop
     // can embed it as ?t= in the QR. The phone uses cookie auth via the WS
     // upgrade, but cookies don't cross devices — the token in the QR is what

--- a/server/src/tabPersist.js
+++ b/server/src/tabPersist.js
@@ -384,7 +384,41 @@ function _writeScrollbackSync(tabMgr) {
     } catch (_) { /* best-effort */ }
 }
 
+// Multiset of live (non-exited) tab cwds across the given sessions — the
+// "already running" side of restore-on-connect. Counted fleet-wide, not per
+// session: the saved list describes the whole fleet, and the fleet may be alive
+// in ANOTHER session (a lapsed cookie, a phone bound to a fresh token session).
+// Re-opening those here `claude --resume`s agents that are already running —
+// the 2026-08-25 duplication (16 agents, 8 of them doubled or tripled).
+function liveCwdCounts(sessionsIterable) {
+    const counts = new Map();
+    for (const s of sessionsIterable || []) {
+        if (!s || !s.tabMgr) continue;
+        for (const id of s.tabMgr.order) {
+            const t = s.tabMgr.tabs.get(id);
+            if (t && t.cwd && !t.exited) counts.set(t.cwd, (counts.get(t.cwd) || 0) + 1);
+        }
+    }
+    return counts;
+}
+
+// Which saved entries to (re)open given the live multiset. Each live tab consumes
+// one matching saved entry, so a project with several saved tabs still restores
+// fully when only some are alive. Pure; does not mutate `liveByCwd`.
+function planRestore(savedTabs, liveByCwd) {
+    const remaining = new Map(liveByCwd || []);
+    const open = [];
+    let skipped = 0;
+    (savedTabs || []).forEach((entry, index) => {
+        const have = (entry && remaining.get(entry.cwd)) || 0;
+        if (have > 0) { remaining.set(entry.cwd, have - 1); skipped++; return; }
+        open.push({ entry, index });
+    });
+    return { open, skipped };
+}
+
 module.exports = {
+    liveCwdCounts, planRestore,
     load, loadScrollback, loadLastGood, loadSession, saveSession,
     save, saveImmediate, saveAll, reconcileTabsFromScrollback,
     noteUserClose,

--- a/server/src/tunnel.js
+++ b/server/src/tunnel.js
@@ -29,6 +29,20 @@ const { ensureCloudflared } = require('./tunnelProvision');
 // when the desktop is redeployed or refreshed.
 const STATE_FILE = require('./stateDir').stateFile('tunnel.json');
 
+// cloudflared gives up and EXITS once a connection has failed to reconnect this
+// many times (its default is 5). A laptop sleeping through more than a few
+// backoff rounds came back to a dead tunnel twice on 2026-08-25, and a quick
+// tunnel has a single connection — no HA sibling to carry it. Retry far longer.
+const CF_RETRIES = String(parseInt(process.env.SOA_WEB_CF_RETRIES || '40', 10) || 40);
+// Cloudflare publishes the *.trycloudflare.com record a few seconds AFTER
+// cloudflared prints the URL. Handing it out before then means the first client
+// lookup is an NXDOMAIN that resolvers cache for the zone's negative TTL (30 min
+// — every fresh link looked "down" on 2026-08-25). Wait, bounded, for DoH to
+// see the A record before the URL goes anywhere.
+const CF_DNS_WAIT_MS = parseInt(process.env.SOA_WEB_CF_DNS_WAIT_MS || '20000', 10);
+// cloudflared keeps logging for the life of the tunnel; keep only the tail.
+const CF_LOG_CAP = 64 * 1024;
+
 function _saveState(state) {
     try {
         fs.mkdirSync(path.dirname(STATE_FILE), { recursive: true });
@@ -60,6 +74,18 @@ function _dohResolve4(host) {
         req.on('error', () => resolve(null));
         req.setTimeout(5000, () => { try { req.destroy(); } catch (_) {} resolve(null); });
     });
+}
+
+// Poll DoH until `host` has an A record, or the budget runs out (then publish
+// anyway — a late record is better than no tunnel).
+async function _waitForDns(host, budgetMs) {
+    const deadline = Date.now() + budgetMs;
+    while (Date.now() < deadline) {
+        if (await _dohResolve4(host)) return true;
+        await new Promise(r => setTimeout(r, 1000));
+    }
+    dbg('tunnel', 'DNS for', host, 'not visible via DoH after', budgetMs, 'ms — publishing anyway');
+    return false;
 }
 
 // One GET to url/api/ping. opts.ip pins a resolved IP via a custom lookup (the
@@ -196,20 +222,21 @@ async function _tryCloudflared(port, onProgress) {
         // _findCloudflaredPid. Without it a standalone binary self-updates
         // (~24h) and re-execs, minting a NEW trycloudflare URL out from under
         // the paired phone and defeating adopt()'s same-URL restart survival.
-        const proc = spawn(cfPath, ['tunnel', '--url', `http://localhost:${port}`, '--no-autoupdate'], {
+        const proc = spawn(cfPath, ['tunnel', '--url', `http://localhost:${port}`, '--retries', CF_RETRIES, '--no-autoupdate'], {
             stdio: ['ignore', 'pipe', 'pipe'],
             detached: true,
         });
 
+        let buf = '';
         const url = await new Promise((resolve, reject) => {
             const timeout = setTimeout(() => {
                 dbg('tunnel', 'cloudflared timed out after 30s waiting for URL; last output:', buf.slice(-400));
                 try { proc.kill(); } catch (_) {}
                 reject(new Error('cloudflared timeout'));
             }, 30000);
-            let buf = '';
             const onData = chunk => {
                 buf += chunk.toString();
+                if (buf.length > CF_LOG_CAP) buf = buf.slice(-CF_LOG_CAP);
                 // (?!api\.) — cloudflared's own log mentions its API endpoint
                 // https://api.trycloudflare.com while REQUESTING the tunnel;
                 // matching the first *.trycloudflare.com in the buffer handed
@@ -227,16 +254,22 @@ async function _tryCloudflared(port, onProgress) {
             proc.on('exit', code => { clearTimeout(timeout); dbg('tunnel', 'cloudflared exited early, code', code, '— output:', buf.slice(-400)); reject(new Error('cloudflared exit ' + code)); });
         });
 
+        let host = null;
+        try { host = new URL(url).hostname; } catch (_) {}
+        if (host) await _waitForDns(host, CF_DNS_WAIT_MS);
+
         // Remember it and let the parent exit independently of it.
         _saveState({ provider: 'cloudflared', url, pid: proc.pid, port, startedAt: Date.now() });
         try { proc.unref(); } catch (_) {}
 
         let dead = false;
         let onDeath = null;
-        proc.on('exit', () => {
+        proc.on('exit', (code, signal) => {
             if (dead) return;
             dead = true;
-            dbg('tunnel', 'cloudflared process exited (tunnel down):', url);
+            // Always logged (not just dbg): two silent deaths on 2026-08-25 left
+            // nothing to diagnose. The tail of cloudflared's own log says why.
+            console.log(`SoA-Web tunnel: cloudflared exited (code ${code}${signal ? ', signal ' + signal : ''}) — ${url} is down. Last output: ${buf.slice(-800).replace(/\s+/g, ' ')}`);
             _clearState();
             if (onDeath) onDeath();
         });

--- a/server/src/tunnelGate.js
+++ b/server/src/tunnelGate.js
@@ -34,8 +34,19 @@ function httpMayProvision({ isLocal, openTunnel, sessionTokenMode }) {
 // tabs; then — only for trusted callers — the primary-share / new-session
 // fallback the local desktop relies on. A remote caller with none of those is
 // an anonymous tunnel visitor → reject (no primary-share to strangers).
-function decideWsBind({ tokenSession, existingHasTabs, isLocal, openTunnel, sessionTokenMode }) {
-    if (tokenSession)   return { action: 'bind', source: 'token',  via: 'pair-token' };
+function decideWsBind({ tokenSession, tokenSessionHasTabs, existingHasTabs, isLocal, openTunnel, sessionTokenMode, primaryExists }) {
+    if (tokenSession) {
+        // The pairing token proves the caller was handed this session's QR by
+        // its owner. But when that session is EMPTY while a populated primary
+        // exists (the desktop's cookie lapsed and it was re-provisioned, then
+        // shared its new token), binding to it shows the phone no tabs and —
+        // worse — lets restore-on-connect rehydrate the saved fleet next to
+        // the one already running. Share the primary; the token stays the
+        // authorization. Callers that don't report primaryExists keep the old
+        // token-wins behaviour.
+        if (tokenSessionHasTabs || !primaryExists) return { action: 'bind', source: 'token', via: 'pair-token' };
+        return { action: 'bind', source: 'primary-or-new', via: 'primary-over-empty-token' };
+    }
     if (existingHasTabs) return { action: 'bind', source: 'cookie', via: 'cookie' };
     if (isLocal || openTunnel || sessionTokenMode) {
         return { action: 'bind', source: 'primary-or-new', via: 'primary-share' };

--- a/server/test/pairing.test.js
+++ b/server/test/pairing.test.js
@@ -1,0 +1,103 @@
+// PairingManager tunnel lifecycle. 2026-08-25: cloudflared exited twice (laptop
+// slept through its reconnect budget) and the manager sat in `error` until a
+// human clicked START — the phone's link was dead for hours each time. The
+// manager must re-open the tunnel on its own, announce the new URL, and never
+// resurrect a tunnel the user stopped or one that died during shutdown.
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const os = require('node:os');
+const path = require('node:path');
+
+process.env.SOA_WEB_STATE_DIR = path.join(os.tmpdir(), `soa-web-pairing-test-${process.pid}`);
+
+const { PairingManager } = require('../src/pairing');
+
+// A tunnel handle shaped like tunnel.js returns: url, close(), and an onDeath
+// setter the manager subscribes to. `kill()` simulates the process dying.
+function fakeTunnel(url) {
+    let onDeath = null;
+    return {
+        url,
+        closed: false,
+        close() { this.closed = true; },
+        set onDeath(fn) { onDeath = fn; },
+        kill() { if (onDeath) onDeath(); },
+    };
+}
+
+function mkManager({ urls, restartDelayMs = 5 } = {}) {
+    const opened = [];
+    const openTunnel = async (port) => {
+        const url = urls.shift();
+        if (!url) return null;
+        const t = fakeTunnel(url);
+        opened.push(t);
+        return t;
+    };
+    const pair = new PairingManager({ port: 4010, openTunnel, adopt: async () => null, restartDelayMs });
+    return { pair, opened };
+}
+
+const tick = (ms) => new Promise(r => setTimeout(r, ms));
+
+test('pairing: a dead tunnel is re-opened automatically and the new URL is announced', async () => {
+    const { pair, opened } = mkManager({ urls: ['https://one.trycloudflare.com', 'https://two.trycloudflare.com'] });
+    const announced = [];
+    pair.onTunnelUp = (url) => announced.push(url);
+    const snap = await pair.start();
+    assert.equal(snap.state, 'online');
+    assert.equal(snap.publicUrl, 'https://one.trycloudflare.com');
+
+    opened[0].kill();
+    assert.equal(pair.state, 'error', 'death is visible immediately');
+    assert.match(pair.error, /restarting/);
+
+    await tick(40);
+    assert.equal(pair.state, 'online');
+    assert.equal(pair.publicUrl, 'https://two.trycloudflare.com');
+    assert.deepEqual(announced, ['https://two.trycloudflare.com']);
+    assert.equal(opened.length, 2);
+});
+
+test('pairing: keeps retrying while the provider is still down', async () => {
+    const { pair, opened } = mkManager({ urls: ['https://one.trycloudflare.com', null, null, 'https://back.trycloudflare.com'] });
+    await pair.start();
+    opened[0].kill();
+    await tick(80);
+    assert.equal(pair.state, 'online');
+    assert.equal(pair.publicUrl, 'https://back.trycloudflare.com');
+    pair.stop();
+});
+
+test('pairing: stop() is final — no auto-restart after an explicit stop', async () => {
+    const { pair, opened } = mkManager({ urls: ['https://one.trycloudflare.com', 'https://two.trycloudflare.com'] });
+    await pair.start();
+    pair.stop();
+    assert.equal(pair.state, 'idle');
+    opened[0].kill();   // late exit notification from the process we just closed
+    await tick(40);
+    assert.equal(pair.state, 'idle');
+    assert.equal(opened.length, 1, 'no second tunnel was opened');
+});
+
+test('pairing: detach() (daemon shutdown) never restarts a tunnel that dies afterwards', async () => {
+    const { pair, opened } = mkManager({ urls: ['https://one.trycloudflare.com', 'https://two.trycloudflare.com'] });
+    await pair.start();
+    const t = opened[0];
+    pair.detach();
+    t.kill();
+    await tick(40);
+    assert.equal(opened.length, 1);
+    assert.equal(pair.tunnel, null);
+});
+
+test('pairing: a manual start() during the restart window cancels the pending timer (one tunnel, not two)', async () => {
+    const { pair, opened } = mkManager({ urls: ['https://one.trycloudflare.com', 'https://two.trycloudflare.com', 'https://three.trycloudflare.com'], restartDelayMs: 30 });
+    await pair.start();
+    opened[0].kill();
+    await pair.start();   // the user clicks START before the 30ms auto-restart fires
+    await tick(80);
+    assert.equal(opened.length, 2, 'the auto-restart did not open a third tunnel');
+    assert.equal(pair.publicUrl, 'https://two.trycloudflare.com');
+    pair.stop();
+});

--- a/server/test/tabPersist.test.js
+++ b/server/test/tabPersist.test.js
@@ -185,3 +185,44 @@ test('post-recovery: a transient empty must NOT clobber or tombstone a scrollbac
 });
 
 test.after(() => { try { fs.rmSync(TMP, { recursive: true, force: true }); } catch (_) {} });
+
+// ── restore-on-connect planning: fleet-wide "already live" accounting ─────────
+// 2026-08-25: the live multiset was counted for the CONNECTING session only, so
+// a phone binding to a fresh empty session re-opened (and `claude --resume`d)
+// every tab of the fleet already running in the desktop's session.
+function mkSession(tabs) {
+    const map = new Map();
+    tabs.forEach((t, i) => map.set(i + 1, { cwd: t.cwd, exited: !!t.exited }));
+    return { tabMgr: { order: [...map.keys()], tabs: map } };
+}
+
+test('liveCwdCounts: counts live tabs across every session, skipping exited shells', () => {
+    const counts = tabPersist.liveCwdCounts([
+        mkSession([{ cwd: '/a' }, { cwd: '/b' }]),
+        mkSession([{ cwd: '/a' }, { cwd: '/c', exited: true }]),
+        { tabMgr: null },
+        null,
+    ]);
+    assert.deepEqual([...counts.entries()].sort(), [['/a', 2], ['/b', 1]]);
+});
+
+test('planRestore: a live tab anywhere consumes one saved entry; extras still open', () => {
+    const saved = [{ cwd: '/a' }, { cwd: '/a' }, { cwd: '/a' }, { cwd: '/b' }, { cwd: '/d' }];
+    const live = new Map([['/a', 2], ['/b', 1]]);
+    const plan = tabPersist.planRestore(saved, live);
+    assert.equal(plan.skipped, 3);
+    assert.deepEqual(plan.open.map(o => [o.index, o.entry.cwd]), [[2, '/a'], [4, '/d']]);
+    assert.equal(live.get('/a'), 2, 'input multiset is not mutated');
+});
+
+test('planRestore: nothing live → everything opens, keeping saved indexes for scrollback pairing', () => {
+    const plan = tabPersist.planRestore([{ cwd: '/x' }, { cwd: '/y' }], new Map());
+    assert.equal(plan.skipped, 0);
+    assert.deepEqual(plan.open.map(o => o.index), [0, 1]);
+});
+
+test('planRestore: fully-live fleet → opens nothing (no duplicate agents)', () => {
+    const plan = tabPersist.planRestore([{ cwd: '/x' }, { cwd: '/y' }], new Map([['/x', 1], ['/y', 3]]));
+    assert.equal(plan.open.length, 0);
+    assert.equal(plan.skipped, 2);
+});

--- a/server/test/tunnelGate.test.js
+++ b/server/test/tunnelGate.test.js
@@ -1,0 +1,53 @@
+// WS bind decisions. The 2026-08-25 regression: a pairing token for an EMPTY
+// session (the desktop's cookie had lapsed and it was silently re-provisioned)
+// bound the phone to that empty session, and restore-on-connect then rehydrated
+// the whole saved fleet beside the one still running. An empty token session
+// must defer to a populated primary; a token session WITH tabs still wins.
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { decideWsBind, httpMayProvision } = require('../src/tunnelGate');
+
+const tok = { id: 'tok' };
+
+test('decideWsBind: token session with tabs binds to the token session', () => {
+    const d = decideWsBind({ tokenSession: tok, tokenSessionHasTabs: true, primaryExists: true, isLocal: false });
+    assert.deepEqual(d, { action: 'bind', source: 'token', via: 'pair-token' });
+});
+
+test('decideWsBind: EMPTY token session + live primary → share the primary, not the empty session', () => {
+    const d = decideWsBind({ tokenSession: tok, tokenSessionHasTabs: false, primaryExists: true, isLocal: false });
+    assert.equal(d.action, 'bind');
+    assert.equal(d.source, 'primary-or-new');
+    assert.equal(d.via, 'primary-over-empty-token');
+});
+
+test('decideWsBind: empty token session with NO primary anywhere still binds to the token (boot / first pair)', () => {
+    const d = decideWsBind({ tokenSession: tok, tokenSessionHasTabs: false, primaryExists: false, isLocal: false });
+    assert.deepEqual(d, { action: 'bind', source: 'token', via: 'pair-token' });
+});
+
+test('decideWsBind: legacy callers that omit the new fields keep token-wins behaviour', () => {
+    const d = decideWsBind({ tokenSession: tok, existingHasTabs: false, isLocal: false, openTunnel: false, sessionTokenMode: false });
+    assert.equal(d.source, 'token');
+});
+
+test('decideWsBind: populated cookie session wins over primary', () => {
+    const d = decideWsBind({ tokenSession: null, existingHasTabs: true, isLocal: true, primaryExists: true });
+    assert.deepEqual(d, { action: 'bind', source: 'cookie', via: 'cookie' });
+});
+
+test('decideWsBind: local caller with an empty/no cookie session shares the primary', () => {
+    const d = decideWsBind({ tokenSession: null, existingHasTabs: false, isLocal: true });
+    assert.deepEqual(d, { action: 'bind', source: 'primary-or-new', via: 'primary-share' });
+});
+
+test('decideWsBind: remote caller without token or populated session is rejected', () => {
+    const d = decideWsBind({ tokenSession: null, existingHasTabs: false, isLocal: false, openTunnel: false, sessionTokenMode: false });
+    assert.equal(d.action, 'reject');
+});
+
+test('httpMayProvision: remote anonymous callers cannot mint sessions unless the tunnel is open', () => {
+    assert.equal(httpMayProvision({ isLocal: false, openTunnel: false, sessionTokenMode: false }), false);
+    assert.equal(httpMayProvision({ isLocal: true, openTunnel: false, sessionTokenMode: false }), true);
+});

--- a/server/test/unit.test.js
+++ b/server/test/unit.test.js
@@ -234,3 +234,21 @@ test('tabManager: cwd change rewrites auto title and re-runs disambiguation', ()
     mgr._refreshAutoTitles();
     assert.deepEqual(mgr.list().map(t => t.title), ['Hireal', 'other']);
 });
+
+test('auth: issuedAt reads iat from a signed cookie and rejects tampering', () => {
+    const key = 'x'.repeat(32);
+    const before = Date.now();
+    const cookie = auth.issue('tok', key);
+    const iat = auth.issuedAt(cookie, key);
+    assert.ok(iat >= before && iat <= Date.now());
+    assert.equal(auth.issuedAt(cookie + 'x', key), null);
+    assert.equal(auth.issuedAt(cookie, 'y'.repeat(32)), null);
+});
+
+test('auth: shouldRenew slides the cookie once it is a day old (or unreadable)', () => {
+    const now = 10_000_000_000;
+    assert.equal(auth.shouldRenew(now - 1000, now), false);
+    assert.equal(auth.shouldRenew(now - auth.COOKIE_RENEW_AFTER_MS + 1, now), false);
+    assert.equal(auth.shouldRenew(now - auth.COOKIE_RENEW_AFTER_MS, now), true);
+    assert.equal(auth.shouldRenew(null, now), true);
+});


### PR DESCRIPTION
Root-cause fixes for the two 2026-08-25 incidents.

### Tunnel — "tunnel down" twice in one evening
- **Auto-restart**: cloudflared exited after the Mac slept through its 5 reconnect retries, and `PairingManager` parked in `error` until someone clicked START. It now re-opens the tunnel itself (5 s delay, keeps retrying while the provider is down, never after an explicit `stop()` or during shutdown) and announces the new URL via `onTunnelUp` so the origin is re-allowed.
- **`--retries 40`** (`SOA_WEB_CF_RETRIES`) so a sleep no longer exhausts cloudflared.
- **Publish only once DNS exists**: wait (≤20 s, DoH) for the new `*.trycloudflare.com` A record before handing the URL out — the first lookup used to be an NXDOMAIN that resolvers cached for the zone's 30-min negative TTL, so every fresh link looked dead.
- **Deaths are logged** (exit code + tail of cloudflared's own output, 64 KB bounded buffer). Both deaths on the 25th left nothing to read.

### Session — 16 agents doubled or tripled
The 7-day auth cookie lapsed mid-session → browser re-provisioned onto an **empty** session → phone bound to it via its pairing token → `restore-on-connect` rehydrated the whole saved fleet **beside the one still running** (`claude --resume` ×2–3 per session).
- **Sliding cookie renewal** after a day (`auth.shouldRenew`/`issuedAt`).
- **Empty token session defers to a populated primary** (`decideWsBind`); legacy callers unchanged.
- **Restore plan counts live cwds across every session** (`tabPersist.liveCwdCounts`/`planRestore`) — a running agent is never resumed twice.

**Tests:** 19 new — `pairing.test.js` (auto-restart, stop/detach finality, manual-start cancels the timer), `tunnelGate.test.js`, restore planning, cookie renewal. Suite 163/163.

🤖 Generated with [Claude Code](https://claude.com/claude-code)