### PR TITLE
Context canvas: a rail you can pull, drag and resize — and a Time Machine that rebuilds the fleet

### DIFF
--- a/server/src/fleetRestore.js
+++ b/server/src/fleetRestore.js
@@ -1,0 +1,236 @@
+/**
+ * fleetRestore — ONE implementation of "bring the terminals back".
+ *
+ * The fleet has been rebuilt by hand three times now (2026-06-29, 2026-07-08,
+ * 2026-08-31), and each time the same five steps ran in the same order:
+ *
+ *   1. pick the richest surviving list of tabs — tabs.json, else the protected
+ *      tabs.json.lastgood, else a rotated tabs.json.bak-*, else the per-tab cwds
+ *      that scrollback.json still carries;
+ *   2. drop entries whose cwd no longer exists on disk;
+ *   3. skip cwds that are ALREADY open, counting duplicates as a multiset — three
+ *      blueprint tabs on one cwd must restore three tabs, not one;
+ *   4. open the rest as real tabs on the live session;
+ *   5. resume each one's Claude conversation, giving tabs that share a cwd
+ *      DISTINCT recent session ids (newest first) so two agents never attach to
+ *      the same transcript.
+ *
+ * That workflow lives here so every caller runs the same code: the Time Machine's
+ * Restore button, the `soa-restore-fleet` CLI, and anything else that needs the
+ * fleet back. It deliberately does NOT need the manager entitlement — recovering
+ * your own terminals is not a premium fleet-control action, and the 2026-08-31
+ * loss was made worse by the recovery CLI failing on an unlicensed install.
+ *
+ * Non-destructive by construction: it only ever OPENS tabs. Nothing here closes,
+ * stops, or rewrites a live tab, so running it twice is a no-op the second time.
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const tabPersist = require('./tabPersist');
+const claudeSessions = require('./claudeSessions');
+const sessionManager = require('./sessionManager');
+const envStore = require('./envStore');
+
+const PROJECTS_DIR = path.join(os.homedir(), '.claude', 'projects');
+const SAFE_ID = /^[A-Za-z0-9_-]+$/;
+// Stagger cold-starts: a dozen `claude --resume` processes launched in the same
+// tick fight over CPU and the machine stalls for a minute.
+const LAUNCH_STAGGER_MS = parseInt(process.env.SOA_WEB_RESTORE_STAGGER_MS || '1500', 10);
+const MAX_TABS = 40;
+
+function _norm(list) {
+    if (!Array.isArray(list)) return [];
+    const out = [];
+    for (const t of list) {
+        if (!t || typeof t.cwd !== 'string' || !t.cwd) continue;
+        out.push({
+            cwd: t.cwd,
+            title: (t.userRenamed || t.renamed) && t.title ? String(t.title).slice(0, 64) : (t.title ? String(t.title).slice(0, 64) : null),
+            userRenamed: !!(t.userRenamed || t.renamed),
+        });
+        if (out.length >= MAX_TABS) break;
+    }
+    return out;
+}
+
+/**
+ * The richest surviving tab list, and where it came from. Order matters: a live
+ * tabs.json is the truth when it still holds a fleet, but a COLLAPSED one (0-1
+ * tabs, the loss signature) must not shadow the protected snapshot behind it.
+ */
+function pickSource(explicit) {
+    const explicitTabs = _norm(explicit);
+    if (explicitTabs.length) return { from: 'request', tabs: explicitTabs };
+
+    const meta = _norm((tabPersist.load() || {}).tabs);
+    if (meta.length >= 2) return { from: 'tabs.json', tabs: meta };
+
+    const lastgood = _norm((tabPersist.loadLastGood() || {}).tabs);
+    if (lastgood.length >= 2) return { from: 'lastgood', tabs: lastgood };
+
+    let baks = [];
+    try {
+        const dir = path.dirname(tabPersist.STATE_FILE);
+        baks = fs.readdirSync(dir).filter(f => /^tabs\.json\.bak-/.test(f)).sort().reverse()
+            .map(f => path.join(dir, f));
+    } catch (_) { /* no backups — fall through to scrollback */ }
+    for (const b of baks) {
+        try {
+            const t = _norm(JSON.parse(fs.readFileSync(b, 'utf8')).tabs);
+            if (t.length >= 2) return { from: path.basename(b), tabs: t };
+        } catch (_) { /* skip a corrupt backup, try the next */ }
+    }
+
+    // scrollback.json carries the live title but not userRenamed; a title that
+    // differs from the cwd basename is a rename worth keeping.
+    const sb = (tabPersist.loadScrollback() || {}).tabs;
+    const fromSb = _norm((Array.isArray(sb) ? sb : []).map(t => t && ({
+        cwd: t.cwd, title: t.title,
+        userRenamed: !!(t.title && t.cwd && t.title !== path.basename(t.cwd)),
+    })));
+    if (fromSb.length >= 2) return { from: 'scrollback', tabs: fromSb };
+
+    return { from: 'none', tabs: [] };
+}
+
+/**
+ * cwd -> [sessionId…] newest first. Unlike claudeSessions.latestSessionByCwd
+ * (one id per cwd, which is all boot-restore needs) this keeps the whole list,
+ * because tabs that SHARE a cwd each need their own conversation.
+ */
+function recentSessionsByCwd(wanted, hours = 168) {
+    const cutoff = Date.now() - hours * 3600 * 1000;
+    const want = new Set(wanted);
+    const byCwd = new Map();
+    let entries;
+    try { entries = fs.readdirSync(PROJECTS_DIR); } catch (_) { return byCwd; }
+    for (const entry of entries) {
+        if (entry.startsWith('wf_') || entry === 'subagents') continue;
+        if (entry.startsWith('-private-tmp') || entry.startsWith('-tmp')) continue;
+        const dir = path.join(PROJECTS_DIR, entry);
+        let files;
+        try { files = fs.readdirSync(dir).filter(f => f.endsWith('.jsonl')); } catch (_) { continue; }
+        for (const f of files) {
+            const sessionId = path.basename(f, '.jsonl');
+            if (!SAFE_ID.test(sessionId)) continue;
+            let mtime = 0;
+            try { mtime = fs.statSync(path.join(dir, f)).mtimeMs; } catch (_) { continue; }
+            if (mtime < cutoff) continue;
+            const cwd = claudeSessions.resolveCwd(path.join(dir, f));
+            if (!cwd || !want.has(cwd)) continue;
+            if (!byCwd.has(cwd)) byCwd.set(cwd, []);
+            byCwd.get(cwd).push({ sessionId, mtime });
+        }
+    }
+    for (const list of byCwd.values()) list.sort((a, b) => b.mtime - a.mtime);
+    return byCwd;
+}
+
+/**
+ * Rebuild the fleet on `session`. Returns a report — never throws for a single
+ * bad entry, because a restore that gives up halfway is worse than one that
+ * reports what it could not do.
+ *
+ *   opts.tabs    explicit [{cwd,title,userRenamed}] (the Time Machine passes the
+ *                snapshot's tabs); omitted → the best on-disk source
+ *   opts.resume  launch `claude --resume <id>` in each opened tab (default true)
+ *   opts.dryRun  plan only
+ */
+function restoreFleet(session, opts = {}) {
+    const resume = opts.resume !== false;
+    const dryRun = !!opts.dryRun;
+    if (!session || !session.tabMgr) return { ok: false, error: 'no active session', opened: [], skipped: [] };
+
+    const src = pickSource(opts.tabs);
+    if (!src.tabs.length) return { ok: false, error: 'no fleet source found', from: src.from, opened: [], skipped: [] };
+
+    // Multiset of live cwds: each live tab consumes one saved entry, so a project
+    // with three tabs still restores the two that are missing.
+    const live = new Map();
+    for (const id of session.tabMgr.order) {
+        const t = session.tabMgr.tabs.get(id);
+        if (t && t.cwd) live.set(t.cwd, (live.get(t.cwd) || 0) + 1);
+    }
+
+    const plan = [];
+    const skipped = [];
+    for (const entry of src.tabs) {
+        if (!fs.existsSync(entry.cwd)) { skipped.push({ ...entry, why: 'missing dir' }); continue; }
+        const have = live.get(entry.cwd) || 0;
+        if (have > 0) { live.set(entry.cwd, have - 1); skipped.push({ ...entry, why: 'already open' }); continue; }
+        plan.push(entry);
+    }
+
+    // Hand out distinct transcripts to tabs sharing a cwd, newest first.
+    const sessions = resume ? recentSessionsByCwd(plan.map(t => t.cwd)) : new Map();
+    const taken = new Map();
+    for (const entry of plan) {
+        const list = sessions.get(entry.cwd) || [];
+        const i = taken.get(entry.cwd) || 0;
+        taken.set(entry.cwd, i + 1);
+        entry.sessionId = list[i] ? list[i].sessionId : null;
+    }
+
+    if (dryRun) return { ok: true, from: src.from, dryRun: true, opened: plan, skipped };
+
+    const shellEnv = envStore.getEnvForShell();
+    const opened = [];
+    for (const entry of plan) {
+        let tab;
+        try {
+            tab = session.tabMgr.open({
+                title: entry.userRenamed && entry.title ? entry.title : undefined,
+                cwd: entry.cwd,
+                env: shellEnv,
+                silent: true,
+            });
+        } catch (e) {
+            skipped.push({ ...entry, why: `open failed: ${(e && e.message) || e}` });
+            continue;
+        }
+        if (!tab) { skipped.push({ ...entry, why: 'open returned nothing' }); continue; }
+        opened.push({ id: tab.id, title: tab.title, cwd: entry.cwd, sessionId: entry.sessionId || null });
+    }
+
+    if (resume) {
+        opened.forEach(({ id, cwd, sessionId }, n) => {
+            setTimeout(() => {
+                const tab = session.tabMgr.get(id);
+                if (!tab) return;   // closed while we waited — nothing to launch into
+                try {
+                    sessionManager.launchClaude(tab, cwd, {
+                        resume: true, sessionId: sessionId || null, coldFallback: false,
+                    });
+                } catch (_) { /* a failed launch leaves a usable shell — never fatal */ }
+            }, n * LAUNCH_STAGGER_MS);
+        });
+    }
+
+    try { tabPersist.saveImmediate(session.tabMgr); } catch (_) {}
+    console.log(`fleet-restore: opened ${opened.length} tab(s) from ${src.from}`
+        + (skipped.length ? ` (${skipped.length} skipped)` : '')
+        + (resume ? ` · resuming ${opened.filter(o => o.sessionId).length}` : ''));
+
+    return { ok: true, from: src.from, opened, skipped, resumed: resume };
+}
+
+function mount(app, requireAuthed, sessions) {
+    // Restoring your own terminals is not a manager action: no entitlement gate,
+    // same auth as /api/tabs. The 2026-08-31 recovery was blocked because the
+    // only restore path went through the licensed fleet-control surface.
+    app.post('/api/fleet/restore', requireAuthed, (req, res) => {
+        const s = (req.session && req.session.tabMgr) ? req.session
+            : [...sessions.sessions.values()].find(x => x.tabMgr) || null;
+        if (!s) return res.status(503).json({ ok: false, error: 'no active session' });
+        const body = req.body || {};
+        const out = restoreFleet(s, {
+            tabs: body.tabs, resume: body.resume !== false, dryRun: !!body.dryRun,
+        });
+        res.status(out.ok ? 200 : 409).json(out);
+    });
+}
+
+module.exports = { mount, restoreFleet, pickSource, recentSessionsByCwd };

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -52,6 +52,7 @@ const procMem          = require('./procMem');
 const claudeSessions   = require('./claudeSessions');
 const contextCanvas    = require('./contextCanvas');
 const tabApi           = require('./tabApi');
+const fleetRestore     = require('./fleetRestore');
 const envStore         = require('./envStore');
 const autoCompact      = require('./autoCompact');
 const autoPilot        = require('./autoPilot');
@@ -460,6 +461,7 @@ pairing.mount(app, requireAuthed, pair, {
     },
 });
 tabApi.mount(app, requireAuthed, sessions);
+fleetRestore.mount(app, requireAuthed, sessions);
 envStore.mount(app, requireAuthed);
 autoCompact.mount(app, requireAuthed);
 autoPilot.mount(app, requireAuthed);

--- a/web/public/assets/app-wc.js
+++ b/web/public/assets/app-wc.js
@@ -17,7 +17,7 @@
 import { AudioFX } from '/assets/audiofx.js?v=18';
 import { t as tr, getLang, setLang, applyStatic, LANGS } from '/assets/i18n.js?v=29';
 import { mountSandboxSidebar } from '/assets/widgets.js?v=47';
-import { getSettings, onSettings, openSettingsModal } from '/assets/settings.js?v=25';
+import { getSettings, onSettings, openSettingsModal } from '/assets/settings.js?v=26';
 // The WebContainer API is vendored into /assets/vendor (was esm.sh, but a
 // cross-origin static import makes the whole module graph — and therefore
 // the dynamic import of this file — fail whenever the CDN is slow, blocked,

--- a/web/public/assets/app.js
+++ b/web/public/assets/app.js
@@ -20,9 +20,9 @@ import { Bridge, INPUT_KIND } from '/assets/bridge.js?v=17';
 import { AudioFX } from '/assets/audiofx.js?v=18';
 import { mountSidebar, setSidebarHidden } from '/assets/widgets.js?v=47';
 import { t as tr, getLang, setLang, applyStatic, LANGS } from '/assets/i18n.js?v=29';
-import { getSettings, onSettings, openSettingsModal, saveSettings, iso2ToFlagEmoji } from '/assets/settings.js?v=25';
+import { getSettings, onSettings, openSettingsModal, saveSettings, iso2ToFlagEmoji } from '/assets/settings.js?v=26';
 import { pickFolder } from '/assets/folderPicker.js?v=1';
-import { mountContextPanel } from '/assets/contextPanel.js?v=1';
+import { mountContextPanel } from '/assets/contextPanel.js?v=3';
 import { resolveTheme, xtermTheme, applyThemeAttr, onSystemThemeChange } from '/assets/theme.js?v=3';
 
 const CFG = (window.__SOA_WEB__ = window.__SOA_WEB__ || {});
@@ -368,8 +368,11 @@ class TabRuntime {
 }
 
 class Shell {
-    constructor(bridge, { audio } = {}) {
+    constructor(bridge, { audio, backend } = {}) {
         this.bridge = bridge;
+        // Kept so features loaded later (time machine, fleet restore) can reach
+        // the same daemon the WS is bound to, not just the page origin.
+        this.backend = backend || '';
         this.audio = audio || { play: () => {}, setEnabled: () => {} };
         this.tabs = new Map();
         // id -> cwd, straight off the snapshot; the context canvas reads the active
@@ -547,7 +550,7 @@ class Shell {
             tmBtn.addEventListener('click', async () => {
                 this.audio.play('panels');
                 try {
-                    const tm = await import('/assets/timemachine.js?v=2');
+                    const tm = await import('/assets/timemachine.js?v=3');
                     tm.openTimemachineModal(this);
                 } catch (err) {
                     console.warn('[timemachine] open failed', err);
@@ -659,13 +662,21 @@ class Shell {
             if (saved != null) ctxOff = saved === '1';
         } catch (_) {}
         stageEl.classList.toggle('no-context', ctxOff);
+        const ctxPull = $('#ctx-pull');
         const setContextOff = (off) => {
             stageEl.classList.toggle('no-context', off);
+            // The pull tab's chevron is CSS-driven off .no-context; only the
+            // a11y state needs syncing here.
+            if (ctxPull) ctxPull.setAttribute('aria-expanded', off ? 'false' : 'true');
             try { localStorage.setItem('soa_context_off', off ? '1' : '0'); } catch (_) {}
             this._fitActive();
         };
-        if (ctxBtn) {
-            ctxBtn.addEventListener('click', () => {
+        // Reflect the initial state without persisting it: an unvisited phone
+        // shouldn't have "closed" written into localStorage as a preference.
+        if (ctxPull) ctxPull.setAttribute('aria-expanded', ctxOff ? 'false' : 'true');
+        for (const el of [ctxBtn, ctxPull]) {
+            if (!el) continue;
+            el.addEventListener('click', () => {
                 setContextOff(!stageEl.classList.contains('no-context'));
                 this.audio.play('panels');
             });
@@ -6231,6 +6242,8 @@ async function bootServerMode({ backend, token }) {
     mountContextPanel($('#context'), {
         backend,
         getCwd: () => shell._tabCwd.get(shell.activeId) || null,
+        // A width drag changes the terminal column, so re-fit the grid as it moves.
+        onResize: () => shell._fitActive(),
     });
 
     setTimeout(() => {
@@ -6244,7 +6257,7 @@ async function bootServerMode({ backend, token }) {
         audio.play('theme');
     }, s0.nointro ? 0 : 250);
 
-    import('/assets/timemachine.js?v=2')
+    import('/assets/timemachine.js?v=3')
         .then(tm => tm.startTimemachine(shell))
         .catch(err => console.warn('[timemachine] boot failed', err));
 }

--- a/web/public/assets/contextPanel.js
+++ b/web/public/assets/contextPanel.js
@@ -9,6 +9,13 @@
  *
  * Three bands, in the order you need them: what you asked (prompts), where you
  * are (workspace), what is left (next steps).
+ *
+ * Every edge is draggable. The panel's left border sets its width; the divider
+ * above WORKSPACE and above NEXT STEPS sets that band's height, with the prompt
+ * thread absorbing the slack. Sizes live in localStorage (per browser, like the
+ * sidebar and panel toggles), are clamped so no drag can push a band off-panel,
+ * and reset on double-click. The grips are built ONCE in _build() — renders only
+ * ever replace band BODIES, so a drag survives every tick and every rebind.
  */
 
 const el = (tag, props = {}, children = []) => {
@@ -37,6 +44,21 @@ function ago(ms) {
     return `${Math.round(s / 86400)}d`;
 }
 
+// Drag limits. WIDTH_MIN keeps the mono micro-type readable; BAND_MIN keeps a
+// band's header plus one row visible, so a band can be tucked away small but
+// never dragged out of existence.
+const WIDTH_MIN = 190, WIDTH_MAX = 720;
+const BAND_MIN = 42;
+const LS_WIDTH = 'soa_ctx_w', LS_BANDS = 'soa_ctx_bands';
+const KEY_STEP = 8;
+
+function lsGet(k, fallback) {
+    try { const v = localStorage.getItem(k); return v == null ? fallback : v; } catch (_) { return fallback; }
+}
+function lsSet(k, v) { try { localStorage.setItem(k, v); } catch (_) {} }
+function lsDel(k) { try { localStorage.removeItem(k); } catch (_) {} }
+const clamp = (n, lo, hi) => Math.min(hi, Math.max(lo, n));
+
 const STATUS_CYCLE = { pending: 'in_progress', in_progress: 'completed', completed: 'pending' };
 const STATUS_MARK = { pending: '○', in_progress: '◐', completed: '●' };
 
@@ -48,7 +70,13 @@ class ContextCanvas {
         this.sessionId = null;
         this.steps = [];
         this._pinned = true;
+        // Called after any size change so the terminal grid can re-fit into the
+        // width the panel just gave back (or took).
+        this.onResize = ctx.onResize || (() => {});
+        this._bands = {};
+        this._applySavedWidth();
         this._build();
+        this._applySavedBands();
         this._timer = setInterval(() => this.tick(), 2500);
         this.tick();
     }
@@ -83,22 +111,151 @@ class ContextCanvas {
             },
         });
 
+        this._factsBand = el('div', { class: 'ctx-band ctx-band-facts' }, [
+            this._bandGrip('facts', 'WORKSPACE'),
+            el('div', { class: 'ctx-band-h' }, [el('span', { text: 'WORKSPACE' })]),
+            this._facts,
+        ]);
+        this._stepsBand = el('div', { class: 'ctx-band ctx-band-steps' }, [
+            this._bandGrip('steps', 'NEXT STEPS'),
+            el('div', { class: 'ctx-band-h' }, [el('span', { text: 'NEXT STEPS' })]),
+            this._stepList,
+            this._stepInput,
+        ]);
+        this._threadBand = el('div', { class: 'ctx-band ctx-band-thread' }, [
+            el('div', { class: 'ctx-band-h' }, [el('span', { text: 'PROMPTS' }), this._sub]),
+            this._thread,
+        ]);
+
         this.root.replaceChildren(
+            this._widthGrip(),
             head,
-            el('div', { class: 'ctx-band ctx-band-thread' }, [
-                el('div', { class: 'ctx-band-h' }, [el('span', { text: 'PROMPTS' }), this._sub]),
-                this._thread,
-            ]),
-            el('div', { class: 'ctx-band' }, [
-                el('div', { class: 'ctx-band-h' }, [el('span', { text: 'WORKSPACE' })]),
-                this._facts,
-            ]),
-            el('div', { class: 'ctx-band' }, [
-                el('div', { class: 'ctx-band-h' }, [el('span', { text: 'NEXT STEPS' })]),
-                this._stepList,
-                this._stepInput,
-            ]),
+            this._threadBand,
+            this._factsBand,
+            this._stepsBand,
         );
+    }
+
+    // ── Drag machinery ──────────────────────────────────────────────────────
+    // One pointer-capture drag for both axes: capture means the pointer keeps
+    // reporting to the grip even when it leaves the 7px hit strip, so a fast
+    // drag can't "slip off" the handle mid-gesture.
+    _drag(grip, onStart, onMove, onReset) {
+        grip.addEventListener('pointerdown', (e) => {
+            if (e.button !== 0) return;
+            e.preventDefault();
+            const start = onStart(e);
+            // Capture keeps a fast drag glued to the handle; it can throw when the
+            // pointer isn't active (synthetic events, exotic input), and the window
+            // listeners below are what actually make the drag work either way.
+            try { grip.setPointerCapture(e.pointerId); } catch (_) {}
+            grip.classList.add('dragging');
+            document.body.classList.add('ctx-resizing');
+            const move = (ev) => onMove(ev, start);
+            const up = () => {
+                window.removeEventListener('pointermove', move);
+                window.removeEventListener('pointerup', up);
+                window.removeEventListener('pointercancel', up);
+                window.removeEventListener('blur', up);
+                grip.classList.remove('dragging');
+                document.body.classList.remove('ctx-resizing');
+                this.onResize();
+            };
+            // On window, not the grip: a drag that outruns the 7px strip (or ends
+            // outside the viewport, or loses focus) must still land its pointerup,
+            // otherwise the panel stays stuck in resize mode.
+            window.addEventListener('pointermove', move);
+            window.addEventListener('pointerup', up);
+            window.addEventListener('pointercancel', up);
+            window.addEventListener('blur', up);
+        });
+        // A handle you can't undo is a trap: double-click restores the default.
+        grip.addEventListener('dblclick', (e) => { e.preventDefault(); onReset(); this.onResize(); });
+    }
+
+    _widthGrip() {
+        const grip = el('div', {
+            class: 'ctx-grip ctx-grip-w', role: 'separator', tabindex: '0',
+            'aria-orientation': 'vertical', 'aria-label': 'Resize context canvas width',
+            title: 'Drag to resize · double-click to reset',
+        });
+        const width = () => this.root.getBoundingClientRect().width;
+        const setW = (w) => {
+            const px = clamp(Math.round(w), WIDTH_MIN, Math.min(WIDTH_MAX, Math.round(window.innerWidth * 0.6)));
+            document.documentElement.style.setProperty('--soa-ctx-w', px + 'px');
+            lsSet(LS_WIDTH, String(px));
+        };
+        this._drag(grip,
+            (e) => ({ x: e.clientX, w: width() }),
+            // The panel is on the RIGHT, so dragging left (negative dx) grows it.
+            (ev, s) => { setW(s.w + (s.x - ev.clientX)); this.onResize(); },
+            () => { document.documentElement.style.removeProperty('--soa-ctx-w'); lsDel(LS_WIDTH); },
+        );
+        grip.addEventListener('keydown', (e) => {
+            const d = e.key === 'ArrowLeft' ? KEY_STEP : e.key === 'ArrowRight' ? -KEY_STEP : 0;
+            if (!d) return;
+            e.preventDefault();
+            setW(width() + d);
+            this.onResize();
+        });
+        return grip;
+    }
+
+    _bandGrip(key, label) {
+        const grip = el('div', {
+            class: 'ctx-grip ctx-grip-h', role: 'separator', tabindex: '0',
+            'aria-orientation': 'horizontal', 'aria-label': `Resize ${label} band`,
+            title: 'Drag to resize · double-click to reset',
+        });
+        const band = () => grip.parentElement;
+        const setH = (h) => {
+            const b = band();
+            if (!b) return;
+            // Never let a band grow past what the panel can give the thread.
+            const room = this.root.clientHeight - 120;
+            const px = clamp(Math.round(h), BAND_MIN, Math.max(BAND_MIN, room));
+            b.style.flex = `0 0 ${px}px`;
+            this._bands[key] = px;
+            lsSet(LS_BANDS, JSON.stringify(this._bands));
+        };
+        this._drag(grip,
+            (e) => ({ y: e.clientY, h: band().getBoundingClientRect().height }),
+            // The grip sits on the band's TOP edge: dragging up grows it.
+            (ev, s) => setH(s.h + (s.y - ev.clientY)),
+            () => {
+                const b = band();
+                if (b) b.style.flex = '';
+                delete this._bands[key];
+                lsSet(LS_BANDS, JSON.stringify(this._bands));
+            },
+        );
+        grip.addEventListener('keydown', (e) => {
+            const d = e.key === 'ArrowUp' ? KEY_STEP : e.key === 'ArrowDown' ? -KEY_STEP : 0;
+            if (!d) return;
+            e.preventDefault();
+            setH(band().getBoundingClientRect().height + d);
+        });
+        return grip;
+    }
+
+    _applySavedWidth() {
+        const w = parseInt(lsGet(LS_WIDTH, ''), 10);
+        if (Number.isFinite(w) && w >= WIDTH_MIN) {
+            document.documentElement.style.setProperty(
+                '--soa-ctx-w', clamp(w, WIDTH_MIN, WIDTH_MAX) + 'px');
+        }
+    }
+
+    _applySavedBands() {
+        let saved = {};
+        try { saved = JSON.parse(lsGet(LS_BANDS, '{}')) || {}; } catch (_) { saved = {}; }
+        const targets = { facts: this._factsBand, steps: this._stepsBand };
+        for (const [k, band] of Object.entries(targets)) {
+            const px = parseInt(saved[k], 10);
+            if (!Number.isFinite(px) || px < BAND_MIN) continue;
+            band.style.flex = `0 0 ${px}px`;
+            this._bands[k] = px;
+        }
     }
 
     async tick() {

--- a/web/public/assets/settings.js
+++ b/web/public/assets/settings.js
@@ -27,7 +27,9 @@ export const DEFAULTS = Object.freeze({
     cursorBlink: true,
     nocursor: false,
     nointro: false,
-    audio: true,
+    // Sound FX default to MUTED: a terminal that chirps on every panel toggle is
+    // a surprise on first run, and someone who wants it turns it on once.
+    audio: false,
     audioVolume: 1.0,
     disableFeedbackAudio: false,
     agentDoneSound: true,

--- a/web/public/assets/sidebar.css
+++ b/web/public/assets/sidebar.css
@@ -1,8 +1,8 @@
 /* ── Sidebar layout ─────────────────────────────────────────────────────
    The stage is a two-column grid when the sidebar is visible, collapsing
    to a single-column terminal when toggled off. */
-.stage { grid-template-columns: var(--soa-sidebar-w, 256px) 1fr var(--soa-ctx-w, 340px); grid-template-areas: 'sidebar terms context' 'status status status'; }
-.stage.no-sidebar { grid-template-columns: 1fr var(--soa-ctx-w, 340px); grid-template-areas: 'terms context' 'status status'; }
+.stage { grid-template-columns: var(--soa-sidebar-w, 256px) 1fr var(--soa-ctx-w, 256px); grid-template-areas: 'sidebar terms context' 'status status status'; }
+.stage.no-sidebar { grid-template-columns: 1fr var(--soa-ctx-w, 256px); grid-template-areas: 'terms context' 'status status'; }
 .stage.no-context { grid-template-columns: var(--soa-sidebar-w, 256px) 1fr; grid-template-areas: 'sidebar terms' 'status status'; }
 .stage.no-sidebar.no-context { grid-template-columns: 1fr; grid-template-areas: 'terms' 'status'; }
 .terms { grid-area: terms; }
@@ -429,12 +429,46 @@
    stack of instruments. */
 .context-panel {
     grid-area: context;
+    /* Anchor for the width grip that rides the panel's left border. */
+    position: relative;
     border-left: 1px solid var(--soa-line);
     background: var(--soa-bg-panel);
     display: flex; flex-direction: column;
     min-width: 0; overflow: hidden;
 }
 .stage.no-context .context-panel { display: none; }
+
+/* ── Context pull tab ───────────────────────────────────────────────────
+   The canvas is tucked away and pulled back out from its OWN edge, so the
+   affordance lives where the motion happens instead of in the topbar. The
+   handle rides the panel's outer border and slides to the viewport edge when
+   the panel closes — it never disappears, only the chevron flips. */
+.ctx-pull {
+    position: absolute; top: 50%; right: var(--soa-ctx-w, 256px);
+    transform: translateY(-50%);
+    width: 15px; min-height: 88px; padding: 11px 0 13px;
+    display: flex; flex-direction: column; align-items: center; gap: 8px;
+    background: var(--soa-bg-panel);
+    border: 1px solid var(--soa-line); border-right: none;
+    border-radius: 4px 0 0 4px;
+    font-family: var(--font-mono); font-size: 9px; letter-spacing: 0.2em;
+    color: var(--soa-accent-dim); cursor: pointer; z-index: 7;
+    transition: right 160ms ease, color 160ms ease, border-color 160ms ease,
+                box-shadow 160ms ease;
+}
+.stage.no-context .ctx-pull { right: 0; }
+.ctx-pull:hover {
+    color: var(--soa-accent); border-color: var(--soa-accent-dim);
+    box-shadow: -5px 0 16px rgba(var(--soa-accent-rgb), 0.14);
+}
+.ctx-pull:focus-visible { outline: 1px solid var(--soa-accent); outline-offset: 1px; }
+/* The glyph points the way the panel will travel, so it reads as a direction
+   rather than a state. Rendered in CSS: the class on .stage is the only source
+   of truth for open/closed, and JS never has to keep a glyph in sync. */
+.ctx-pull-chev { font-size: 10px; line-height: 1; }
+.ctx-pull-chev::before { content: '\203A'; }
+.stage.no-context .ctx-pull-chev::before { content: '\2039'; }
+.ctx-pull-label { writing-mode: vertical-rl; text-orientation: mixed; }
 
 .ctx-head {
     display: flex; align-items: baseline; justify-content: space-between; gap: 8px;
@@ -448,10 +482,14 @@
 
 /* Bands stack; only the thread flexes, so WORKSPACE and NEXT STEPS keep their
    height and the prompt history absorbs the rest of the column. */
-.ctx-band { display: flex; flex-direction: column; min-height: 0;
+/* Only the thread may flex. Every other band is flex: 0 0 auto — without the
+   explicit no-shrink, the default (0 1 auto) let the thread's tall content
+   squeeze WORKSPACE and NEXT STEPS until the panel's overflow:hidden clipped
+   them mid-glyph, which is what the canvas looked like on a short viewport. */
+.ctx-band { display: flex; flex-direction: column; min-height: 0; flex: 0 0 auto;
     border-bottom: 1px solid var(--soa-line-soft); }
 .ctx-band:last-child { border-bottom: none; }
-.ctx-band-thread { flex: 1 1 auto; min-height: 120px; }
+.ctx-band-thread { flex: 1 1 auto; min-height: 96px; }
 .ctx-band-h {
     display: flex; align-items: baseline; justify-content: space-between; gap: 8px;
     padding: 7px 12px 5px; flex: 0 0 auto;
@@ -485,7 +523,8 @@
 }
 .ctx-turn.latest .ctx-turn-x { max-height: none; }
 
-.ctx-facts { padding: 2px 12px 9px; display: flex; flex-direction: column; gap: 2px; }
+.ctx-facts { padding: 2px 12px 9px; display: flex; flex-direction: column; gap: 2px;
+    min-height: 0; overflow-y: auto; }
 .ctx-fact { display: grid; grid-template-columns: 52px 1fr; gap: 8px;
     font-family: var(--font-mono); font-size: 10px; align-items: baseline; }
 .ctx-fact-k { color: var(--soa-accent-dim); letter-spacing: 0.12em; }
@@ -493,7 +532,7 @@
     text-overflow: ellipsis; white-space: nowrap; direction: rtl; text-align: left; }
 
 .ctx-steps { padding: 2px 12px 4px; display: flex; flex-direction: column; gap: 1px;
-    max-height: 30vh; overflow-y: auto; }
+    max-height: min(30vh, 260px); overflow-y: auto; }
 .ctx-step { display: grid; grid-template-columns: auto 1fr auto; gap: 7px;
     align-items: baseline; font-family: var(--font-mono); font-size: 10.5px; }
 .ctx-step-mark, .ctx-step-del {
@@ -516,13 +555,52 @@
 .ctx-step-add::placeholder { color: var(--soa-accent-dim); opacity: 0.6; }
 .ctx-step-add:focus { outline: none; border-color: var(--soa-accent); }
 
+/* ── Resize grips ───────────────────────────────────────────────────────
+   Every edge of the canvas is draggable: the left border sets the width, the
+   divider above a band sets that band's height. The hit strip is 7px (a
+   comfortable pointer target) but the visible line is 1px and only lights up
+   on hover or during a drag, so the chrome stays quiet until you reach for it. */
+.ctx-grip { z-index: 8; }
+.ctx-grip::after {
+    content: ''; position: absolute; background: transparent;
+    transition: background 140ms ease;
+}
+.ctx-grip:hover::after, .ctx-grip.dragging::after { background: var(--soa-accent-dim); }
+.ctx-grip.dragging::after { box-shadow: 0 0 10px rgba(var(--soa-accent-rgb), 0.5); }
+.ctx-grip:focus-visible { outline: 1px solid var(--soa-accent); outline-offset: -1px; }
+
+.ctx-grip-w {
+    position: absolute; top: 0; left: -4px; width: 7px; height: 100%;
+    cursor: col-resize;
+}
+.ctx-grip-w::after { top: 0; bottom: 0; left: 3px; width: 1px; }
+
+.ctx-grip-h {
+    position: relative; flex: 0 0 auto; height: 7px; margin-bottom: -3px;
+    cursor: row-resize;
+}
+.ctx-grip-h::after { left: 10px; right: 10px; top: 3px; height: 1px; }
+
+/* While dragging, the cursor must not flicker to a text caret over the text the
+   pointer happens to cross, and nothing should select. */
+body.ctx-resizing { user-select: none; -webkit-user-select: none; }
+body.ctx-resizing * { cursor: inherit !important; }
+
 /* Below this width three columns stop being readable, so the canvas becomes an
    overlay on the terminal — the same move the sidebar already makes. */
 @media (max-width: 1100px) {
     .stage, .stage.no-sidebar, .stage.no-context, .stage.no-sidebar.no-context { position: relative; }
     .context-panel { position: absolute; top: 0; right: 0; bottom: 24px;
-        width: min(var(--soa-ctx-w, 340px), 86vw); z-index: 6;
+        width: min(var(--soa-ctx-w, 256px), 86vw); z-index: 6;
         box-shadow: -8px 0 24px rgba(0, 0, 0, 0.28); }
+    .ctx-pull { right: min(var(--soa-ctx-w, 256px), 86vw); }
+    .stage.no-context .ctx-pull { right: 0; }
     .stage { grid-template-columns: var(--soa-sidebar-w, 256px) 1fr; grid-template-areas: 'sidebar terms' 'status status'; }
     .stage.no-sidebar { grid-template-columns: 1fr; grid-template-areas: 'terms' 'status'; }
+}
+
+/* On a phone-sized dashboard the handle would sit under the thumb that scrolls
+   the terminal, so the topbar CTX button owns the toggle there. */
+@media (max-width: 640px) {
+    .ctx-pull { display: none; }
 }

--- a/web/public/assets/styles.css
+++ b/web/public/assets/styles.css
@@ -21,6 +21,9 @@
   --soa-line:      rgba(var(--soa-accent-rgb), 0.25);
   --soa-line-soft: rgba(var(--soa-accent-rgb), 0.08);
   --soa-sidebar-w: 256px;
+  /* The context canvas mirrors the sidebar: two equal rails framing the
+     terminal. Derived, not duplicated, so one knob resizes both. */
+  --soa-ctx-w:     var(--soa-sidebar-w, 256px);
   --font-mono:     ui-monospace, "Fira Mono", Menlo, Consolas, monospace;
   --font-display:  "United Sans Medium", ui-sans-serif, system-ui, sans-serif;
 }
@@ -743,7 +746,10 @@ html, body {
 .terms .term {
   position: absolute; inset: 0;
   display: none;
-  padding: 4px 6px;
+  /* No right padding: the grid is measured against this content box, so
+     every px here becomes dead gutter between the last column and the
+     context canvas. Left keeps its 6px so glyphs clear the sidebar edge. */
+  padding: 4px 0 4px 6px;
 }
 .terms .term.active { display: block; }
 .terms .xterm { height: 100%; width: 100%; }
@@ -2446,6 +2452,15 @@ html[data-welcome="1"] body { overflow: hidden; overflow-y: auto; }
 .soa-tm-actions button:hover { border-color: var(--soa-accent); }
 .soa-tm-actions .soa-tm-close { width: 28px; padding: 0; }
 .soa-tm-sub { font-size: 11px; color: rgba(var(--soa-accent-rgb), 0.62); margin: 0 0 8px; }
+/* Restore reports what it did here — rebuilt vs replayed — instead of leaving
+   the user to guess from an unchanged screen. Empty until something happens, so
+   it costs no vertical space at rest. */
+.soa-tm-status { margin: 0 0 8px; font-family: var(--font-mono); font-size: 10.5px;
+    color: var(--soa-accent); min-height: 0; }
+.soa-tm-status:empty { display: none; }
+.soa-tm-status[data-kind="bad"] { color: var(--soa-yellow); }
+.soa-tm-status[data-kind="good"] { color: var(--soa-accent); }
+
 .soa-tm-list { flex: 1 1 auto; overflow: auto; border: 1px solid rgba(var(--soa-accent-rgb), 0.16); padding: 6px; min-height: 120px; }
 .soa-tm-list:empty::before, .soa-tm-list[data-empty]:not([data-empty=""])::before { content: attr(data-empty); display: block; padding: 28px 12px; text-align: center; color: rgba(var(--soa-accent-rgb), 0.5); font-size: 11px; }
 .soa-tm-row { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 8px 8px; border-bottom: 1px dashed rgba(var(--soa-accent-rgb), 0.12); }

--- a/web/public/assets/timemachine.js
+++ b/web/public/assets/timemachine.js
@@ -1,16 +1,32 @@
 /**
  * Timemachine
  *
- * Snapshots the IDE's frontend-visible state every 5 minutes into IndexedDB
- * so the user can rewind to any prior point in the session — even after a
- * reload or browser crash. The browser is the only place this lives; the
- * daemon already persists tabs/scrollback/session separately (see
- * server/src/tabPersist.js — that's authoritative for shell respawn). This
- * is a *view* of what the user was looking at, not a process restore.
+ * Snapshots the IDE's state every 5 minutes into IndexedDB so the user can
+ * rewind to any prior point — even after a reload, a browser crash, or a daemon
+ * restart that took the terminals with it.
+ *
+ * Restore is TWO phases, and phase 1 is the one that was missing:
+ *
+ *   1. REBUILD. The snapshot records each tab's cwd, so restore hands the list to
+ *      the daemon (POST /api/fleet/restore → server/src/fleetRestore.js), which
+ *      reopens every tab that is no longer live and resumes its Claude
+ *      conversation (distinct transcripts for tabs that share a cwd). This is the
+ *      same code path the soa-restore-fleet CLI uses.
+ *   2. REPLAY. Tabs that were ALREADY open get their saved scrollback replayed,
+ *      so the on-screen history comes back too.
+ *
+ * A tab the daemon just reopened is deliberately NOT replayed: `claude --resume`
+ * is already printing the real conversation into it, and interleaving a saved
+ * transcript with live output would garble both. Rebuilt tabs get the real
+ * context; surviving tabs get their view back.
+ *
+ * Snapshots taken before v2 have no cwd (id-only), so they can only replay —
+ * listSnapshots() marks them so the UI can say so instead of silently doing
+ * nothing, which is what "the time machine doesn't work" meant.
  *
  * What we capture per snapshot:
  *   - viewMode, activeId, tab order
- *   - per tab: id, title, scrollback rendered from xterm's active buffer
+ *   - per tab: id, title, cwd, scrollback rendered from xterm's active buffer
  *   - settings JSON, language, per-tab ctx % and agent status
  *
  * Why IndexedDB, not localStorage:
@@ -28,26 +44,48 @@ const STORE = 'snapshots';
 const MAX_SNAPSHOTS = 60;
 const INTERVAL_MS = 5 * 60 * 1000;
 const MAX_LINES_PER_TAB = 4096;
-const SCHEMA_VERSION = 1;
+// v2 adds per-tab cwd — the field that makes REBUILD possible. v1 snapshots stay
+// readable and restore in replay-only mode.
+const SCHEMA_VERSION = 2;
+// A snapshot is worthless if writing it wedges the tab, so IDB work is bounded.
+const IDB_TIMEOUT_MS = 4000;
+// How long to wait for the daemon's reopened tabs to arrive over the WS snapshot.
+const REBUILD_SETTLE_MS = 6000;
 
 let _db = null;
 let _timer = null;
 let _shellRef = null;
+// Sticky: IndexedDB is unavailable in some private/hardened modes, and it fails
+// on the FIRST call. Remember that instead of retrying (and re-warning) forever.
+let _storageError = null;
 
 function _open() {
     if (_db) return Promise.resolve(_db);
+    if (_storageError) return Promise.reject(_storageError);
     return new Promise((resolve, reject) => {
-        const req = indexedDB.open(DB_NAME, DB_VERSION);
+        let req;
+        // `indexedDB` itself can throw on access (blocked site data), not just fail.
+        try { req = indexedDB.open(DB_NAME, DB_VERSION); }
+        catch (err) { _storageError = err; reject(err); return; }
+        // A blocked upgrade (another tab holding an old version) never fires
+        // success OR error — without this timeout the modal spins forever.
+        const timer = setTimeout(() => {
+            _storageError = new Error('IndexedDB did not respond (another tab may be blocking an upgrade)');
+            reject(_storageError);
+        }, IDB_TIMEOUT_MS);
         req.onupgradeneeded = () => {
             const db = req.result;
             if (!db.objectStoreNames.contains(STORE)) {
                 db.createObjectStore(STORE, { keyPath: 'ts' });
             }
         };
-        req.onsuccess = () => { _db = req.result; resolve(_db); };
-        req.onerror = () => reject(req.error);
+        req.onsuccess = () => { clearTimeout(timer); _db = req.result; resolve(_db); };
+        req.onerror = () => { clearTimeout(timer); _storageError = req.error || new Error('IndexedDB open failed'); reject(_storageError); };
+        req.onblocked = () => { /* the timeout above is the escape hatch */ };
     });
 }
+
+export function storageError() { return _storageError ? (_storageError.message || String(_storageError)) : null; }
 
 function _tx(mode) {
     return _open().then(db => db.transaction(STORE, mode).objectStore(STORE));
@@ -59,6 +97,22 @@ function _put(snap) {
         r.onsuccess = () => res();
         r.onerror = () => rej(r.error);
     }));
+}
+
+// Quota is the one write failure worth fighting: drop the oldest half and retry
+// once, so a full store degrades to a shorter history instead of no history.
+async function _putTolerant(snap) {
+    try { await _put(snap); return true; }
+    catch (err) {
+        const quota = err && (err.name === 'QuotaExceededError' || /quota/i.test(err.name || err.message || ''));
+        if (!quota) throw err;
+        const all = await _all();
+        all.sort((a, b) => a.ts - b.ts);
+        for (let i = 0; i < Math.ceil(all.length / 2); i++) await _delete(all[i].ts);
+        console.warn('[timemachine] storage full — pruned oldest half and retrying');
+        await _put(snap);
+        return true;
+    }
 }
 
 function _all() {
@@ -129,6 +183,9 @@ export async function snapshotNow(shell) {
         tabs.push({
             id,
             title: rt.title || `tab #${id}`,
+            // The field that makes a rebuild possible. Without it a snapshot can
+            // only ever repaint tabs that still exist.
+            cwd: (shell._tabCwd && shell._tabCwd.get(id)) || null,
             scrollback: _dumpScrollback(rt),
         });
     }
@@ -148,12 +205,17 @@ export async function snapshotNow(shell) {
         ctxPct,
         agentStatus,
     };
+    // Never snapshot an empty fleet over a good history: a snapshot taken during
+    // boot (or right after a daemon restart, before tabs rehydrate) would
+    // otherwise become the newest entry and look like "everything was closed".
+    if (!tabs.length) return null;
     try {
-        await _put(snap);
+        await _putTolerant(snap);
         await _prune();
-        console.log(`[timemachine] saved snapshot at ${new Date(ts).toLocaleTimeString()} (${tabs.length} tabs)`);
+        console.log(`[timemachine] saved snapshot at ${new Date(ts).toLocaleTimeString()} (${tabs.length} tabs, ${tabs.filter(t => t.cwd).length} with cwd)`);
     } catch (err) {
         console.warn('[timemachine] save failed', err);
+        return null;
     }
     return snap;
 }
@@ -164,6 +226,9 @@ export async function listSnapshots() {
     return all.map(s => ({
         ts: s.ts,
         tabCount: (s.tabs || []).length,
+        // A snapshot can rebuild only the tabs whose cwd it recorded.
+        cwdCount: (s.tabs || []).filter(t => t && t.cwd).length,
+        v: s.v || 1,
         avgCtx: _avgCtx(s),
         viewMode: s.viewMode,
     }));
@@ -186,18 +251,106 @@ export async function getSnapshot(ts) {
 export async function deleteSnapshot(ts) { return _delete(ts); }
 export async function clearAll() { return _clear(); }
 
+function _api(shell, p) {
+    const base = (shell && shell.backend ? String(shell.backend) : '').replace(/\/+$/, '');
+    try { return new URL(base + p, location.origin).toString(); }
+    catch (_) { return p; }
+}
+
+/** cwd -> count, over the tabs currently live in the shell. */
+function _liveByCwd(shell) {
+    const m = new Map();
+    for (const id of shell.order || []) {
+        const cwd = shell._tabCwd && shell._tabCwd.get(id);
+        if (cwd) m.set(cwd, (m.get(cwd) || 0) + 1);
+    }
+    return m;
+}
+
 /**
- * Restore a snapshot into the live UI. We don't respawn shells (the daemon
- * owns PTY identity); instead we replay each saved tab's rendered scrollback
- * into the matching live tab, prefixed by a divider, so the user lands on
- * the same view they had at snapshot time. Tabs that no longer exist are
- * skipped — a future enhancement could open new shells at the saved cwd,
- * but that requires the daemon to expose cwd-per-tab in the snapshot, which
- * tabPersist already does on its own cadence.
+ * Phase 1 — REBUILD. Ask the daemon to reopen every snapshot tab that is no
+ * longer live and resume its Claude conversation. Returns the ids the daemon
+ * opened (so phase 2 knows not to replay into them) plus a human summary.
+ *
+ * Failure here is never fatal: if the endpoint is missing (older daemon) or the
+ * call fails, we fall through to a replay-only restore and say so.
+ */
+async function _rebuild(snap, shell) {
+    const want = (snap.tabs || []).filter(t => t && t.cwd);
+    if (!want.length) {
+        return { openedIds: new Set(), note: (snap.v || 1) < 2
+            ? 'snapshot predates cwd recording — replay only'
+            : 'no cwds in snapshot — replay only' };
+    }
+    // Only send what is actually missing. The daemon does this multiset check
+    // too (it is the authority on what is live) — doing it here as well keeps
+    // the "nothing to rebuild" case from making a pointless round trip.
+    const live = _liveByCwd(shell);
+    const missing = [];
+    for (const t of want) {
+        const have = live.get(t.cwd) || 0;
+        if (have > 0) { live.set(t.cwd, have - 1); continue; }
+        missing.push({ cwd: t.cwd, title: t.title || null, userRenamed: !!t.title });
+    }
+    if (!missing.length) return { openedIds: new Set(), note: 'every tab still open — nothing to rebuild' };
+
+    let r;
+    try {
+        r = await fetch(_api(shell, '/api/fleet/restore'), {
+            method: 'POST', credentials: 'include',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ tabs: missing, resume: true }),
+        });
+    } catch (err) {
+        return { openedIds: new Set(), note: `rebuild unavailable (${err.message}) — replay only` };
+    }
+    if (!r.ok) {
+        return { openedIds: new Set(), note: `rebuild refused (${r.status}) — replay only` };
+    }
+    let out = {};
+    try { out = await r.json(); } catch (_) {}
+    const opened = Array.isArray(out.opened) ? out.opened : [];
+    // The tabs arrive over the WS as a SNAPSHOT frame; wait for the shell to
+    // actually hold them before replaying, so phase 2 matches against reality.
+    if (opened.length) await _settle(shell, (shell.tabs ? shell.tabs.size : 0) + opened.length);
+    return {
+        openedIds: new Set(opened.map(o => o.id)),
+        note: `rebuilt ${opened.length} tab(s) from ${out.from || 'disk'}`
+            + (opened.filter(o => o.sessionId).length ? `, resuming ${opened.filter(o => o.sessionId).length}` : ''),
+    };
+}
+
+// Wait (briefly) for the shell to reach an expected tab count. Resolves early
+// the moment it does, and gives up quietly — a restore must never hang.
+function _settle(shell, expected) {
+    const deadline = Date.now() + REBUILD_SETTLE_MS;
+    return new Promise(resolve => {
+        const poll = () => {
+            if (!shell.tabs || shell.tabs.size >= expected || Date.now() > deadline) return resolve();
+            setTimeout(poll, 150);
+        };
+        poll();
+    });
+}
+
+/**
+ * Restore a snapshot. Two phases, in this order:
+ *
+ *   1. REBUILD closed terminals through the daemon (real cwd, real
+ *      `claude --resume`) — see _rebuild above;
+ *   2. REPLAY saved scrollback into tabs that were already open, matched by cwd
+ *      (a multiset, so three tabs on one cwd each get their own history) and
+ *      falling back to tab id for v1 snapshots that have no cwd.
+ *
+ * Rebuilt tabs are never replayed into: `claude --resume` is already writing the
+ * real conversation there, and two writers would garble each other.
+ *
+ * Returns a report — {ok, rebuilt, replayed, total, note} — so the UI can say
+ * what happened instead of leaving the user guessing.
  */
 export async function restoreSnapshot(ts, shell) {
     const snap = await getSnapshot(ts);
-    if (!snap || !shell) return false;
+    if (!snap || !shell) return { ok: false, note: 'snapshot not found' };
     const stamp = new Date(snap.ts).toLocaleString();
     const divider = `\r\n\x1b[36m─── time machine: restored from ${stamp} ───\x1b[0m\r\n`;
     // Saved scrollback can carry terminal-STATE sequences (mouse tracking,
@@ -206,21 +359,54 @@ export async function restoreSnapshot(ts, shell) {
     // the 2026-07-13 "random typing" flood. Bracket the replay with a reset so
     // the terminal ends in a sane mode. (Mirrors SANE_TERM_RESET server-side.)
     const SANE = '\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?1015l\x1b[?1049l\x1b[?2004l\x1b[?25h\x1b>';
-    let restored = 0;
+
+    const { openedIds, note } = await _rebuild(snap, shell);
+
+    // Build cwd -> [live tab ids] for matching, skipping tabs the daemon just
+    // opened (they are mid `claude --resume`).
+    const byCwd = new Map();
+    for (const id of shell.order || []) {
+        if (openedIds.has(id)) continue;
+        const cwd = (shell._tabCwd && shell._tabCwd.get(id)) || null;
+        if (!cwd) continue;
+        if (!byCwd.has(cwd)) byCwd.set(cwd, []);
+        byCwd.get(cwd).push(id);
+    }
+
+    let replayed = 0;
     for (const sav of snap.tabs || []) {
-        const rt = shell.tabs.get(sav.id);
+        // cwd first (survives a daemon restart, which renumbers every tab id),
+        // then the saved id as a fallback for pre-v2 snapshots.
+        let id = null;
+        if (sav.cwd && byCwd.has(sav.cwd) && byCwd.get(sav.cwd).length) id = byCwd.get(sav.cwd).shift();
+        else if (!sav.cwd && shell.tabs.has(sav.id) && !openedIds.has(sav.id)) id = sav.id;
+        if (id == null) continue;
+        const rt = shell.tabs.get(id);
         if (!rt) continue;
         const replay = (sav.scrollback || '').replace(/\n/g, '\r\n');
         rt.write(SANE + divider);
         if (replay) rt.write(replay + '\r\n');
         rt.write(SANE);
-        restored++;
+        replayed++;
     }
-    if (snap.activeId != null && shell.tabs.get(snap.activeId)) {
-        try { shell._activate(snap.activeId); } catch (_) {}
+
+    // Land on the tab that was active, matched by cwd so it survives renumbering.
+    const savedActive = (snap.tabs || []).find(t => t && t.id === snap.activeId);
+    let activate = null;
+    if (savedActive && savedActive.cwd) {
+        for (const id of shell.order || []) {
+            if ((shell._tabCwd && shell._tabCwd.get(id)) === savedActive.cwd) { activate = id; break; }
+        }
     }
-    console.log(`[timemachine] restored ${restored}/${(snap.tabs || []).length} tabs from ${stamp}`);
-    return true;
+    if (activate == null && snap.activeId != null && shell.tabs.has(snap.activeId)) activate = snap.activeId;
+    if (activate != null) { try { shell._activate(activate); } catch (_) {} }
+
+    const report = {
+        ok: true, rebuilt: openedIds.size, replayed,
+        total: (snap.tabs || []).length, note, stamp,
+    };
+    console.log(`[timemachine] restore from ${stamp}: rebuilt ${report.rebuilt}, replayed ${report.replayed}/${report.total} — ${note}`);
+    return report;
 }
 
 export function startTimemachine(shell) {
@@ -230,9 +416,15 @@ export function startTimemachine(shell) {
     // First snapshot ~30s after boot so we always have a baseline even if
     // the user closes the tab inside the first 5 minutes.
     setTimeout(() => snapshotNow(shell), 30 * 1000);
-    window.addEventListener('beforeunload', () => {
+    // beforeunload is the wrong hook for an ASYNC write — the page can be torn
+    // down before IDB commits, which is why "it never saved my last view" was a
+    // real complaint. visibilitychange→hidden is the one the platform guarantees
+    // to deliver on tab close, backgrounding and mobile app switch.
+    document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState !== 'hidden') return;
         try { snapshotNow(shell); } catch (_) {}
     });
+    window.addEventListener('pagehide', () => { try { snapshotNow(shell); } catch (_) {} });
 }
 
 export function stopTimemachine() {
@@ -273,10 +465,11 @@ export async function openTimemachineModal(shell) {
                     <button class="soa-tm-close" type="button" aria-label="Close">✕</button>
                 </div>
             </header>
-            <p class="soa-tm-sub">Auto-saves your on-screen <em>view</em> every 5 minutes to this browser (up to ${MAX_SNAPSHOTS}). Restoring replays history into open tabs — it does <strong>not</strong> reopen closed terminals. To rebuild lost terminals, restart the daemon or run <code>soa-restore-fleet</code>.</p>
+            <p class="soa-tm-sub">Auto-saves every 5 minutes to this browser (up to ${MAX_SNAPSHOTS}). Restoring <strong>reopens closed terminals</strong> at their saved directory and resumes each one's Claude conversation, then replays saved scrollback into the tabs that were still open.</p>
+            <p class="soa-tm-status" role="status"></p>
             <div class="soa-tm-list" data-empty="Loading…"></div>
             <footer class="soa-tm-foot">
-                <small>Restoring replays scrollback into matching tabs. The daemon's own session restore handles PTY respawn.</small>
+                <small>Rebuilt tabs get the real conversation back via <code>claude --resume</code>; surviving tabs get their on-screen history replayed. Restore only ever opens tabs — it never closes one.</small>
             </footer>
         </div>
     `;
@@ -287,13 +480,15 @@ export async function openTimemachineModal(shell) {
     scrim.querySelector('.soa-tm-close').addEventListener('click', close);
 
     const listEl = scrim.querySelector('.soa-tm-list');
+    const statusEl = scrim.querySelector('.soa-tm-status');
+    const say = (msg, kind = '') => { statusEl.textContent = msg || ''; statusEl.dataset.kind = kind; };
     const render = async () => {
         listEl.dataset.empty = 'Loading…';
         listEl.innerHTML = '';
         let rows;
         try { rows = await listSnapshots(); }
         catch (err) {
-            listEl.dataset.empty = 'Storage unavailable.';
+            listEl.dataset.empty = `Storage unavailable: ${storageError() || err.message}`;
             console.warn('[timemachine] list failed', err);
             return;
         }
@@ -306,37 +501,44 @@ export async function openTimemachineModal(shell) {
             const row = document.createElement('div');
             row.className = 'soa-tm-row';
             const ctx = r.avgCtx == null ? '' : ` · ctx ~${r.avgCtx}%`;
+            // Say up front what this row can actually do: a v1 snapshot has no
+            // cwds, so it can only repaint tabs that still exist.
+            const kind = r.cwdCount ? `${r.cwdCount} restorable` : 'view only';
             row.innerHTML = `
                 <div class="soa-tm-when">
                     <strong>${_fmt(r.ts)}</strong>
-                    <span class="soa-tm-meta">${_ago(r.ts)} · ${r.tabCount} tab${r.tabCount === 1 ? '' : 's'} · ${r.viewMode || 'tabs'}${ctx}</span>
+                    <span class="soa-tm-meta">${_ago(r.ts)} · ${r.tabCount} tab${r.tabCount === 1 ? '' : 's'} · ${kind} · ${r.viewMode || 'tabs'}${ctx}</span>
                 </div>
                 <div class="soa-tm-row-actions">
                     <button class="soa-tm-restore" type="button">Restore</button>
                     <button class="soa-tm-del" type="button" aria-label="Delete">🗑</button>
                 </div>
             `;
-            row.querySelector('.soa-tm-restore').addEventListener('click', async () => {
-                // Time Machine is a VIEW replay — it can only write history into
-                // tabs that still exist, never reopen closed terminals. If the
-                // snapshot holds more tabs than are open, say so plainly and
-                // point at the real recovery path so nobody burns time here (the
-                // 2026-08-06 "restore does nothing" confusion).
-                const liveCount = shell && shell.tabs ? shell.tabs.size : 0;
-                if (r.tabCount > liveCount) {
-                    alert(
-                        `This snapshot has ${r.tabCount} tabs but only ${liveCount} ${liveCount === 1 ? 'is' : 'are'} open.\n\n` +
-                        `Time Machine only replays on-screen history into tabs that still exist — it cannot reopen closed terminals.\n\n` +
-                        `Closed terminals come back automatically: the daemon rebuilds them from tabs.json (or tabs.json.lastgood) on restart. ` +
-                        `To rebuild them now, run in a terminal:  soa-restore-fleet`
-                    );
+            const restoreBtn = row.querySelector('.soa-tm-restore');
+            restoreBtn.addEventListener('click', async () => {
+                // No confirm dialog: restore is additive — it opens tabs and
+                // replays text, and never closes or overwrites anything. A modal
+                // dialog here also freezes the page for automation and phones.
+                restoreBtn.disabled = true;
+                restoreBtn.textContent = 'Restoring…';
+                say(`Restoring ${_fmt(r.ts)} — reopening terminals…`);
+                try {
+                    const out = await restoreSnapshot(r.ts, shell);
+                    if (!out || !out.ok) { say(`Restore failed: ${(out && out.note) || 'unknown error'}`, 'bad'); }
+                    else {
+                        say(`Restored ${_fmt(r.ts)} · rebuilt ${out.rebuilt} · replayed ${out.replayed}/${out.total} · ${out.note}`, 'good');
+                        setTimeout(close, 2200);
+                    }
+                } catch (err) {
+                    say(`Restore failed: ${err.message}`, 'bad');
+                } finally {
+                    restoreBtn.disabled = false;
+                    restoreBtn.textContent = 'Restore';
                 }
-                if (!confirm(`Replay the saved view from ${_fmt(r.ts)} into matching open tabs? (This does not reopen closed terminals.)`)) return;
-                await restoreSnapshot(r.ts, shell);
-                close();
+                render();
             });
             row.querySelector('.soa-tm-del').addEventListener('click', async () => {
-                await deleteSnapshot(r.ts);
+                try { await deleteSnapshot(r.ts); } catch (err) { say(`Delete failed: ${err.message}`, 'bad'); }
                 render();
             });
             listEl.appendChild(row);
@@ -344,12 +546,25 @@ export async function openTimemachineModal(shell) {
     };
 
     scrim.querySelector('.soa-tm-snap').addEventListener('click', async () => {
-        await snapshotNow(shell);
+        const snap = await snapshotNow(shell);
+        say(snap ? `Snapshot saved · ${snap.tabs.length} tab(s)` : `Snapshot not saved${storageError() ? ` (${storageError()})` : ' (no tabs open)'}`,
+            snap ? 'good' : 'bad');
         render();
     });
-    scrim.querySelector('.soa-tm-clear').addEventListener('click', async () => {
-        if (!confirm('Delete all timemachine snapshots? This cannot be undone.')) return;
-        await clearAll();
+    // Two-step instead of confirm(): the second click inside 4s does it. Same
+    // protection, no blocking dialog.
+    const clearBtn = scrim.querySelector('.soa-tm-clear');
+    let armed = null;
+    clearBtn.addEventListener('click', async () => {
+        if (!armed) {
+            armed = setTimeout(() => { armed = null; clearBtn.textContent = 'Clear all'; say(''); }, 4000);
+            clearBtn.textContent = 'Click again to delete all';
+            say('This deletes every snapshot in this browser and cannot be undone.', 'bad');
+            return;
+        }
+        clearTimeout(armed); armed = null; clearBtn.textContent = 'Clear all';
+        try { await clearAll(); say('All snapshots deleted.'); }
+        catch (err) { say(`Clear failed: ${err.message}`, 'bad'); }
         render();
     });
 

--- a/web/public/assets/widgets.js
+++ b/web/public/assets/widgets.js
@@ -11,7 +11,7 @@
  */
 
 import { t as tr } from '/assets/i18n.js?v=28';
-import { getSettings } from '/assets/settings.js?v=25';
+import { getSettings } from '/assets/settings.js?v=26';
 
 const $el = (tag, props = {}, children = []) => {
     const n = document.createElement(tag);

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -154,8 +154,8 @@
   <link rel="icon" href="/assets/New-icon-transparent.png?v=3" type="image/png" sizes="any">
   <link rel="shortcut icon" href="/assets/New-icon-transparent.png?v=3" type="image/png">
   <link rel="apple-touch-icon" href="/assets/New-icon-transparent.png?v=3">
-  <link rel="stylesheet" href="/assets/styles.css?v=88">
-  <link rel="stylesheet" href="/assets/sidebar.css?v=40">
+  <link rel="stylesheet" href="/assets/styles.css?v=90">
+  <link rel="stylesheet" href="/assets/sidebar.css?v=43">
   <link rel="stylesheet" href="/assets/minimal.css?v=4">
   <link rel="stylesheet" href="/assets/liquid.css?v=10">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@5.3.0/css/xterm.css">
@@ -876,6 +876,12 @@ SOA_WEB_PASSWORD=hunter2 npm install &amp;&amp; npm start</pre>
       <div id="terms" class="terms"></div>
       <aside id="sidebar" class="sidebar"></aside>
       <aside id="context" class="context-panel" aria-label="Session context"></aside>
+      <button id="ctx-pull" class="ctx-pull" aria-controls="context" aria-expanded="true"
+              data-i18n-title="topbar.context_title" title="Toggle context canvas (Ctrl+Shift+K)"
+              aria-label="Toggle context canvas">
+        <span class="ctx-pull-chev" aria-hidden="true"></span>
+        <span class="ctx-pull-label" aria-hidden="true">CTX</span>
+      </button>
       <div class="status-bar">
         <span id="status-session">—</span>
         <span id="status-tabs" data-i18n="status.tabs_other" data-i18n-vars='{"n":0}'>0 tabs</span>
@@ -888,7 +894,7 @@ SOA_WEB_PASSWORD=hunter2 npm install &amp;&amp; npm start</pre>
   <script src="https://cdn.jsdelivr.net/npm/xterm@5.3.0/lib/xterm.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/xterm-addon-fit@0.8.0/lib/xterm-addon-fit.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/xterm-addon-web-links@0.9.0/lib/xterm-addon-web-links.js"></script>
-  <script type="module" src="/assets/app.js?v=145"></script>
+  <script type="module" src="/assets/app.js?v=149"></script>
   <script>
     // Cloudflare Web Analytics — loaded only when a token is configured (Vercel
     // env SOA_WEB_CF_ANALYTICS_TOKEN). Skipped on dev / self-host so localhost


### PR DESCRIPTION
Two changes, both about the right-hand canvas and getting terminals back.

**The canvas is a rail.** It now matches the left sidebar exactly (`--soa-ctx-w`
derives from `--soa-sidebar-w`), and every edge is draggable: left border sets
width, the divider above WORKSPACE / NEXT STEPS sets that band's height, arrow
keys nudge, double-click resets, sizes persist per browser. A vertical pull tab
rides the panel's outer edge and slides to the viewport edge when the canvas is
tucked away, so the affordance never disappears.

Two fixes the drag work exposed: bands are `flex: 0 0 auto` (the default let the
prompt thread squeeze WORKSPACE and NEXT STEPS until `overflow:hidden` clipped
them mid-glyph), and `.terms .term` drops its right padding — the grid is
measured against that content box, so those 6px were dead gutter. Sound FX now
default to muted.

**Time Machine restores for real.** Snapshots recorded tab ids but no cwd, so
Restore could only replay text into tabs that still existed — and after a daemon
restart the ids are renumbered, so it matched nothing. Snapshots are now v2 with
per-tab cwd, and Restore runs REBUILD (the daemon reopens missing tabs and
resumes each conversation) then REPLAY (saved scrollback into the survivors).
Rebuilt tabs are never replayed into; `claude --resume` is already writing the
real conversation there.

`server/src/fleetRestore.js` is now the single implementation of "bring the
terminals back" — the five steps the fleet has been rebuilt by hand with, shared
by the Time Machine and available to the CLI. `POST /api/fleet/restore` is authed
but not entitlement-gated: recovering your own terminals isn't premium fleet
control, and the last loss was made worse by the recovery path failing on an
unlicensed install.

Verified in the isolated browser: width/band drags, clamps, double-click reset
and the band-clipping fix all measured; no band clips at 1024×768. The server
half needs a daemon restart to go live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)