### PR TITLE
Context canvas: artifacts band + soa-ctx, the agent's side of the canvas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,66 @@ Note: when you finish a turn, your final message is **automatically** sent to
 the IM (via a Claude Code Stop hook), so you don't need `soa-msg` for that —
 reach for it for *mid-task* updates and questions.
 
+## Your context canvas (soa-ctx)
+
+The dashboard's right-hand **CONTEXT** panel is a per-session canvas, not a
+read-only view of chat history — and the agent in the tab is one of its authors.
+It is scoped to the Claude session that owns the current directory, so there is
+nothing to look up:
+
+```bash
+soa-ctx                          # the whole canvas: workspace, recent prompts, artifacts, next steps
+soa-ctx json                     # the same payload, for scripting
+soa-ctx steps                    # the NEXT STEPS list
+soa-ctx step add "ship the migration"   # queue a step  (also: done <n> · rm <n> · clear)
+soa-ctx artifacts                # published artifacts
+soa-ctx artifact <url> [title…]  # register one you just published
+```
+
+Four bands: PROMPTS (your turns, from `history.jsonl`), WORKSPACE (dir, branch,
+session, path), **ARTIFACTS**, and NEXT STEPS. Artifacts fill in **by default** —
+the daemon reads published `claude.ai` artifact URLs out of your own transcript,
+so a URL you printed once is on the canvas whether or not you announced it.
+Register one explicitly when you want the title to read well, or when the URL
+never got printed. Next steps seed from `TodoWrite` and are then yours (and the
+user's) to edit; the saved list always wins.
+
+Use it as the durable surface between turns: what you produced and what is left,
+in a place the user can see from their phone and you can read back with one
+command.
+
+## Restoring a lost fleet
+
+If the tabs vanish (empty dashboard, `soa-sessions list` nearly empty), the
+context is almost always still on disk — the daemon keeps `tabs.json`, a
+protected `tabs.json.lastgood`, a rotating ring of `tabs.json.bak-*`, and
+`scrollback.json`, all in the state dir. The recovery is one call, and it is
+non-destructive (it only ever OPENS tabs):
+
+```bash
+curl -sX POST http://127.0.0.1:4010/api/fleet/restore \
+     -H 'content-type: application/json' -d '{}' | head -c 400
+```
+
+That runs `server/src/fleetRestore.js`, which is the workflow the fleet has been
+rebuilt with by hand three times: pick the richest surviving list (tabs.json →
+lastgood → newest backup → the cwds inside scrollback.json), drop entries whose
+directory is gone, skip cwds that are **already open counting duplicates as a
+multiset** (three tabs on one repo must restore three tabs), open the rest, and
+resume each one's Claude conversation with a **distinct** recent session id so
+two agents never attach to the same transcript. The dashboard's Time Machine
+Restore button calls the same endpoint, and the endpoint is not
+entitlement-gated — recovering your own terminals is not premium fleet control.
+
+Two things that have caused a real loss, worth knowing:
+
+- A `closedByUser` tombstone in `tabs.json` (written when a session legitimately
+  closes every tab) makes boot-time self-heal respect the "intent" and skip
+  recovery. If the fleet is down and `tabs.json` is a lone tab, check for that
+  flag before assuming the state is gone.
+- `soa-sessions spawn` needs the Fleet Manager entitlement, so on an unlicensed
+  install the old `soa-restore-fleet` path fails. `/api/fleet/restore` does not.
+
 ## Managing the whole fleet (manager agent)
 
 SoA runs many sessions (tabs), each often a Claude agent. A **manager agent** is

--- a/scripts/soa-ctx
+++ b/scripts/soa-ctx
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+/**
+ * soa-ctx — the session's context canvas, from the agent's side.
+ *
+ * The right-hand CONTEXT panel in the dashboard is not a read-only view of chat
+ * history: it is a per-session canvas, and the agent working in the tab is one of
+ * its authors. This is the CLI for that. Everything is scoped to the Claude
+ * session that owns the current directory, so there is nothing to look up.
+ *
+ *   soa-ctx                          # the whole canvas, as the panel shows it
+ *   soa-ctx json                     # same, as JSON
+ *   soa-ctx steps                    # the NEXT STEPS list
+ *   soa-ctx step add <text…>         # queue a step
+ *   soa-ctx step done <n>            # mark step n complete (1-based)
+ *   soa-ctx step rm <n> | clear
+ *   soa-ctx artifacts                # published artifacts
+ *   soa-ctx artifact <url> [title…]  # register one you just published
+ *
+ * Published artifact URLs are picked out of your transcript automatically, so
+ * ARTIFACTS fills in whether or not you run `artifact`. Register one explicitly
+ * when you want the title to read well, or when the URL never got printed.
+ *
+ * Reads and writes go to the local daemon over loopback (same discovery as
+ * soa-msg: SOA_WEB_PORT, else bridge.json). Nothing leaves the machine.
+ */
+
+const http = require('http');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+function port() {
+    if (process.env.SOA_WEB_PORT) return Number(process.env.SOA_WEB_PORT);
+    for (const dir of [process.env.SOA_WEB_STATE_DIR, path.join(os.homedir(), '.soa-web-local'),
+                       path.join(os.homedir(), '.s0a-local', 'state'), path.join(os.homedir(), '.soa-web')]) {
+        if (!dir) continue;
+        try {
+            const j = JSON.parse(fs.readFileSync(path.join(dir, 'bridge.json'), 'utf8'));
+            if (j && j.port) return Number(j.port);
+        } catch (_) { /* try the next candidate */ }
+    }
+    return 4010;
+}
+
+function req(method, p, body) {
+    const data = body ? JSON.stringify(body) : null;
+    const headers = { 'x-soa-local-key': process.env.SOA_WEB_LOCAL_KEY || '' };
+    if (data) { headers['content-type'] = 'application/json'; headers['content-length'] = Buffer.byteLength(data); }
+    return new Promise((resolve, reject) => {
+        const r = http.request({ host: '127.0.0.1', port: port(), path: p, method, headers, timeout: 8000 }, res => {
+            let b = '';
+            res.on('data', c => b += c);
+            res.on('end', () => {
+                try { resolve(JSON.parse(b)); }
+                catch (_) { reject(new Error(`${res.statusCode} ${b.slice(0, 200)}`)); }
+            });
+        });
+        r.on('error', reject);
+        r.on('timeout', () => { r.destroy(); reject(new Error('daemon did not answer')); });
+        if (data) r.write(data);
+        r.end();
+    });
+}
+
+const cwd = process.env.SOA_CTX_CWD || process.cwd();
+const canvas = () => req('GET', `/api/context?cwd=${encodeURIComponent(cwd)}`).then(r => {
+    if (!r || !r.ok) throw new Error((r && r.error) || 'no canvas for this directory');
+    return r.data;
+});
+
+function ago(ms) {
+    if (!ms) return '';
+    const s = Math.max(0, Math.round((Date.now() - ms) / 1000));
+    if (s < 60) return `${s}s`;
+    if (s < 3600) return `${Math.round(s / 60)}m`;
+    if (s < 86400) return `${Math.round(s / 3600)}h`;
+    return `${Math.round(s / 86400)}d`;
+}
+const MARK = { pending: '○', in_progress: '◐', completed: '●' };
+
+function show(d) {
+    const w = d.workspace || {};
+    console.log(`CONTEXT  ${w.name || cwd}  ·  session ${d.sessionId ? d.sessionId.slice(0, 8) : '—'}  ·  ${d.turns} turns`);
+    console.log(`  dir     ${w.cwd}`);
+    console.log(`  branch  ${w.branch || 'detached'}`);
+    const last = (d.prompts || []).slice(-3);
+    if (last.length) {
+        console.log('\nRECENT PROMPTS');
+        for (const p of last) console.log(`  ${ago(p.at).padStart(4)}  ${p.text.replace(/\s+/g, ' ').slice(0, 90)}`);
+    }
+    console.log('\nARTIFACTS');
+    const arts = [...(d.artifacts || [])].reverse();
+    if (!arts.length) console.log('  nothing published yet');
+    for (const a of arts) console.log(`  ${ago(a.at).padStart(4)}  ${(a.title || a.id).slice(0, 40).padEnd(40)}  ${a.url}`);
+    console.log('\nNEXT STEPS');
+    const steps = d.nextSteps || [];
+    if (!steps.length) console.log('  nothing queued');
+    steps.forEach((s, i) => console.log(`  ${String(i + 1).padStart(2)}. ${MARK[s.status] || '○'} ${s.text}`));
+}
+
+(async () => {
+    const [cmd, ...rest] = process.argv.slice(2);
+    try {
+        if (!cmd || cmd === 'show') return show(await canvas());
+        if (cmd === 'json') return console.log(JSON.stringify(await canvas(), null, 2));
+
+        if (cmd === 'artifacts') {
+            const d = await canvas();
+            for (const a of [...(d.artifacts || [])].reverse()) console.log(`${a.url}  ${a.title || ''}`.trim());
+            return;
+        }
+        if (cmd === 'artifact') {
+            const [url, ...title] = rest;
+            if (!url) throw new Error('usage: soa-ctx artifact <url> [title…]');
+            const d = await canvas();
+            if (!d.sessionId) throw new Error('no Claude session owns this directory yet');
+            const r = await req('POST', '/api/context/artifacts', { sessionId: d.sessionId, url, title: title.join(' ') || null });
+            if (!r.ok) throw new Error(r.error || 'rejected');
+            console.log(`registered · ${r.artifacts.length} artifact(s) on the canvas`);
+            return;
+        }
+        if (cmd === 'steps') {
+            const d = await canvas();
+            (d.nextSteps || []).forEach((s, i) => console.log(`${String(i + 1).padStart(2)}. ${MARK[s.status] || '○'} ${s.text}`));
+            return;
+        }
+        if (cmd === 'step') {
+            const [sub, ...args] = rest;
+            const d = await canvas();
+            if (!d.sessionId) throw new Error('no Claude session owns this directory yet');
+            let steps = (d.nextSteps || []).map(s => ({ text: s.text, status: s.status }));
+            if (sub === 'add') {
+                const text = args.join(' ').trim();
+                if (!text) throw new Error('usage: soa-ctx step add <text…>');
+                steps.push({ text, status: 'pending' });
+            } else if (sub === 'done' || sub === 'rm') {
+                const n = parseInt(args[0], 10);
+                if (!Number.isFinite(n) || n < 1 || n > steps.length) throw new Error(`step ${args[0] || ''} is not on the list`);
+                if (sub === 'done') steps[n - 1].status = 'completed';
+                else steps.splice(n - 1, 1);
+            } else if (sub === 'clear') {
+                steps = [];
+            } else {
+                throw new Error('usage: soa-ctx step add <text…> | done <n> | rm <n> | clear');
+            }
+            const r = await req('POST', '/api/context/steps', { sessionId: d.sessionId, steps });
+            if (!r.ok) throw new Error(r.error || 'rejected');
+            r.steps.forEach((s, i) => console.log(`${String(i + 1).padStart(2)}. ${MARK[s.status] || '○'} ${s.text}`));
+            return;
+        }
+        throw new Error('usage: soa-ctx [show|json|steps|step|artifacts|artifact] — see the header of this script');
+    } catch (e) {
+        console.error(`soa-ctx: ${(e && e.message) || e}`);
+        process.exit(1);
+    }
+})();

--- a/server/src/contextCanvas.js
+++ b/server/src/contextCanvas.js
@@ -8,8 +8,15 @@
  *
  * Sources, all local files Claude Code already writes:
  *   ~/.claude/history.jsonl                     user prompts, tagged {project, sessionId}
- *   ~/.claude/projects/<enc-cwd>/<sid>.jsonl    the transcript — TodoWrite carries next steps
+ *   ~/.claude/projects/<enc-cwd>/<sid>.jsonl    the transcript — TodoWrite + published artifacts
  *   <cwd>/.git/HEAD                             branch, read directly (no shell)
+ *
+ * The canvas is READ-WRITE, and the agent working in the tab is a first-class
+ * author: next steps and artifacts are merged from what the transcript shows and
+ * what the agent registered through /api/context/* (the `soa-ctx` CLI). An agent
+ * publishing an artifact does not have to remember to tell anyone — the URL is
+ * picked out of its own transcript — but it can also post one explicitly, and
+ * read the whole canvas back on its next turn.
  */
 
 const fs = require('fs');
@@ -118,6 +125,50 @@ function nextStepsFrom(file) {
     }));
 }
 
+// Published artifacts, straight out of the transcript. Claude Code prints the
+// URL when an artifact is created or updated, so the last occurrence of an id is
+// its most recent touch — dedupe by id, keep that order, newest last.
+const ARTIFACT_RE = /https:\/\/claude\.ai\/(?:code\/artifact|public\/artifacts)\/([A-Za-z0-9_-]{6,64})/g;
+const MAX_ARTIFACTS = 20;
+
+function artifactsFrom(file) {
+    if (!file) return [];
+    const text = readTail(file, TRANSCRIPT_TAIL_BYTES);
+    const byId = new Map();
+    for (const line of text.split('\n')) {
+        if (!line.includes('claude.ai/')) continue;
+        // A title is worth having but never worth failing over: prefer the
+        // Artifact tool_use input, fall back to the id.
+        let title = null, at = 0;
+        try {
+            const d = JSON.parse(line);
+            at = Date.parse(d.timestamp) || 0;
+            const content = (d.message && d.message.content) || [];
+            if (Array.isArray(content)) {
+                for (const part of content) {
+                    if (part && part.type === 'tool_use' && /artifact/i.test(part.name || '') && part.input) {
+                        title = String(part.input.title || part.input.description || '').slice(0, 80) || null;
+                    }
+                }
+            }
+        } catch (_) { /* not JSON — the URL scan below still works */ }
+        ARTIFACT_RE.lastIndex = 0;
+        let m;
+        while ((m = ARTIFACT_RE.exec(line))) {
+            const id = m[1];
+            const prev = byId.get(id);
+            byId.delete(id);   // re-insert so the most recent mention sorts last
+            byId.set(id, {
+                id, url: m[0],
+                title: title || (prev && prev.title) || null,
+                at: at || (prev && prev.at) || 0,
+                source: 'transcript',
+            });
+        }
+    }
+    return [...byId.values()].slice(-MAX_ARTIFACTS);
+}
+
 // Next steps are the one part of the canvas the user writes. TodoWrite would be
 // the natural source, but no transcript on this machine contains a single
 // TodoWrite call, so a purely derived list would always render empty. Persist an
@@ -126,25 +177,59 @@ function stepsPath(sessionId) {
     return stateFile(path.join('context', `${sessionId}.json`));
 }
 
+function readStore(sessionId) {
+    if (!sessionId) return {};
+    try { return JSON.parse(fs.readFileSync(stepsPath(sessionId), 'utf8')) || {}; }
+    catch (_) { return {}; }
+}
+
+function writeStore(sessionId, patch) {
+    const file = stepsPath(sessionId);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    const next = { ...readStore(sessionId), ...patch, updatedAt: Date.now() };
+    fs.writeFileSync(file, JSON.stringify(next, null, 1));
+    _cache.clear();
+    return next;
+}
+
 function readSteps(sessionId) {
-    if (!sessionId) return null;
-    try {
-        const d = JSON.parse(fs.readFileSync(stepsPath(sessionId), 'utf8'));
-        return Array.isArray(d.steps) ? d.steps : null;
-    } catch (_) {
-        return null;
+    const d = readStore(sessionId);
+    return Array.isArray(d.steps) ? d.steps : null;
+}
+
+// Artifacts an agent registered by hand (soa-ctx artifact <url>). Merged over the
+// transcript-derived list so an explicit title wins over a guessed one.
+function readArtifacts(sessionId) {
+    const d = readStore(sessionId);
+    return Array.isArray(d.artifacts) ? d.artifacts : [];
+}
+
+function writeArtifact(sessionId, { url, title }) {
+    const clean = String(url || '').trim();
+    if (!/^https:\/\/claude\.ai\/[A-Za-z0-9/_-]+$/.test(clean)) throw new Error('claude.ai artifact url required');
+    const id = (clean.match(/([A-Za-z0-9_-]{6,64})\/?$/) || [])[1] || clean;
+    const kept = readArtifacts(sessionId).filter(a => a && a.id !== id);
+    kept.push({ id, url: clean, title: title ? String(title).slice(0, 80) : null, at: Date.now(), source: 'agent' });
+    writeStore(sessionId, { artifacts: kept.slice(-MAX_ARTIFACTS) });
+    return kept;
+}
+
+function mergeArtifacts(sessionId, derived) {
+    const byId = new Map();
+    for (const a of derived || []) byId.set(a.id, a);
+    for (const a of readArtifacts(sessionId)) {
+        const prev = byId.get(a.id);
+        byId.set(a.id, { ...prev, ...a, title: a.title || (prev && prev.title) || null });
     }
+    return [...byId.values()].sort((x, y) => (x.at || 0) - (y.at || 0)).slice(-MAX_ARTIFACTS);
 }
 
 function writeSteps(sessionId, steps) {
-    const file = stepsPath(sessionId);
-    fs.mkdirSync(path.dirname(file), { recursive: true });
     const clean = (Array.isArray(steps) ? steps : []).slice(0, 60).map(s => ({
         text: String((s && s.text) || '').slice(0, 240),
         status: ['completed', 'in_progress', 'pending'].includes(s && s.status) ? s.status : 'pending',
     })).filter(s => s.text);
-    fs.writeFileSync(file, JSON.stringify({ steps: clean, updatedAt: Date.now() }, null, 1));
-    _cache.clear();
+    writeStore(sessionId, { steps: clean });
     return clean;
 }
 
@@ -185,6 +270,8 @@ function contextFor(cwd) {
         prompts,
         // Saved list wins: it is the user's own, and TodoWrite only ever seeds it.
         nextSteps: readSteps(sessionId) || nextStepsFrom(transcript),
+        // Whatever this session published, whether it announced it or not.
+        artifacts: mergeArtifacts(sessionId, artifactsFrom(transcript)),
         turns,
         lastActivity,
         updatedAt: Date.now(),
@@ -205,6 +292,20 @@ function mount(app, requireAuthed) {
             res.json({ ok: true, data: contextFor(path.resolve(cwd)) });
         } catch (e) {
             res.status(500).json({ ok: false, error: String((e && e.message) || e) });
+        }
+    });
+
+    // The agent's own write path: register an artifact it just published, so the
+    // canvas shows it even when the URL never appears in the transcript tail.
+    app.post('/api/context/artifacts', requireAuthed, express.json({ limit: '8kb' }), (req, res) => {
+        const sessionId = String((req.body && req.body.sessionId) || '').trim();
+        if (!/^[A-Za-z0-9_-]{6,64}$/.test(sessionId)) {
+            return res.status(400).json({ ok: false, error: 'valid sessionId required' });
+        }
+        try {
+            res.json({ ok: true, artifacts: writeArtifact(sessionId, req.body || {}) });
+        } catch (e) {
+            res.status(400).json({ ok: false, error: String((e && e.message) || e) });
         }
     });
 

--- a/web/public/assets/app.js
+++ b/web/public/assets/app.js
@@ -22,7 +22,7 @@ import { mountSidebar, setSidebarHidden } from '/assets/widgets.js?v=47';
 import { t as tr, getLang, setLang, applyStatic, LANGS } from '/assets/i18n.js?v=29';
 import { getSettings, onSettings, openSettingsModal, saveSettings, iso2ToFlagEmoji } from '/assets/settings.js?v=26';
 import { pickFolder } from '/assets/folderPicker.js?v=1';
-import { mountContextPanel } from '/assets/contextPanel.js?v=4';
+import { mountContextPanel } from '/assets/contextPanel.js?v=5';
 import { resolveTheme, xtermTheme, applyThemeAttr, onSystemThemeChange } from '/assets/theme.js?v=3';
 
 const CFG = (window.__SOA_WEB__ = window.__SOA_WEB__ || {});

--- a/web/public/assets/app.js
+++ b/web/public/assets/app.js
@@ -22,7 +22,7 @@ import { mountSidebar, setSidebarHidden } from '/assets/widgets.js?v=47';
 import { t as tr, getLang, setLang, applyStatic, LANGS } from '/assets/i18n.js?v=29';
 import { getSettings, onSettings, openSettingsModal, saveSettings, iso2ToFlagEmoji } from '/assets/settings.js?v=26';
 import { pickFolder } from '/assets/folderPicker.js?v=1';
-import { mountContextPanel } from '/assets/contextPanel.js?v=3';
+import { mountContextPanel } from '/assets/contextPanel.js?v=4';
 import { resolveTheme, xtermTheme, applyThemeAttr, onSystemThemeChange } from '/assets/theme.js?v=3';
 
 const CFG = (window.__SOA_WEB__ = window.__SOA_WEB__ || {});

--- a/web/public/assets/contextPanel.js
+++ b/web/public/assets/contextPanel.js
@@ -393,6 +393,9 @@ class ContextCanvas {
         this._sub.textContent = '—';
         this._turns.textContent = '';
         this._thread.replaceChildren(el('p', { class: 'ctx-muted', text: msg }));
+        // Say something in every band, or a canvas with no session reads as a
+        // rendering bug rather than an empty state.
+        this._arts.replaceChildren(el('p', { class: 'ctx-muted', text: '—' }));
     }
 }
 

--- a/web/public/assets/contextPanel.js
+++ b/web/public/assets/contextPanel.js
@@ -7,8 +7,13 @@
  * tabs never leaves a stack of stale canvases behind. Every render replaces its
  * region's children; nothing here appends.
  *
- * Three bands, in the order you need them: what you asked (prompts), where you
- * are (workspace), what is left (next steps).
+ * Four bands, in the order you need them: what you asked (prompts), where you
+ * are (workspace), what you made (artifacts), what is left (next steps).
+ *
+ * ARTIFACTS updates itself: the daemon reads published claude.ai artifact URLs
+ * out of the session's own transcript, and an agent can register one explicitly
+ * (`soa-ctx artifact <url>`). Same for NEXT STEPS — the canvas is a surface the
+ * session's agent writes to and reads back, not just a view of chat history.
  *
  * Every edge is draggable. The panel's left border sets its width; the divider
  * above WORKSPACE and above NEXT STEPS sets that band's height, with the prompt
@@ -97,6 +102,7 @@ class ContextCanvas {
         });
 
         this._facts = el('div', { class: 'ctx-facts' });
+        this._arts = el('div', { class: 'ctx-arts' });
         this._stepList = el('div', { class: 'ctx-steps' });
         this._stepInput = el('input', {
             class: 'ctx-step-add', type: 'text', placeholder: 'add a next step',
@@ -116,6 +122,11 @@ class ContextCanvas {
             el('div', { class: 'ctx-band-h' }, [el('span', { text: 'WORKSPACE' })]),
             this._facts,
         ]);
+        this._artsBand = el('div', { class: 'ctx-band ctx-band-arts' }, [
+            this._bandGrip('arts', 'ARTIFACTS'),
+            el('div', { class: 'ctx-band-h' }, [el('span', { text: 'ARTIFACTS' })]),
+            this._arts,
+        ]);
         this._stepsBand = el('div', { class: 'ctx-band ctx-band-steps' }, [
             this._bandGrip('steps', 'NEXT STEPS'),
             el('div', { class: 'ctx-band-h' }, [el('span', { text: 'NEXT STEPS' })]),
@@ -132,6 +143,7 @@ class ContextCanvas {
             head,
             this._threadBand,
             this._factsBand,
+            this._artsBand,
             this._stepsBand,
         );
     }
@@ -249,7 +261,7 @@ class ContextCanvas {
     _applySavedBands() {
         let saved = {};
         try { saved = JSON.parse(lsGet(LS_BANDS, '{}')) || {}; } catch (_) { saved = {}; }
-        const targets = { facts: this._factsBand, steps: this._stepsBand };
+        const targets = { facts: this._factsBand, arts: this._artsBand, steps: this._stepsBand };
         for (const [k, band] of Object.entries(targets)) {
             const px = parseInt(saved[k], 10);
             if (!Number.isFinite(px) || px < BAND_MIN) continue;
@@ -288,6 +300,7 @@ class ContextCanvas {
         this._turns.textContent = d.prompts.length ? `${d.prompts.length} turns · ${ago(d.lastActivity)}` : '';
         this._renderThread(d.prompts || []);
         this._renderFacts(d.workspace || {}, d);
+        this._renderArtifacts(d.artifacts || []);
         this._renderSteps();
     }
 
@@ -319,6 +332,21 @@ class ContextCanvas {
         this._facts.replaceChildren(...rows.map(([k, v]) => el('div', { class: 'ctx-fact' }, [
             el('span', { class: 'ctx-fact-k', text: k }),
             el('span', { class: 'ctx-fact-v', title: v, text: v }),
+        ])));
+    }
+
+    _renderArtifacts(list) {
+        if (!list.length) {
+            this._arts.replaceChildren(el('p', { class: 'ctx-muted', text: 'nothing published yet' }));
+            return;
+        }
+        // Newest first: the thing you just made is the thing you want to open.
+        this._arts.replaceChildren(...[...list].reverse().map(a => el('a', {
+            class: 'ctx-art', href: a.url, target: '_blank', rel: 'noopener noreferrer',
+            title: a.url,
+        }, [
+            el('span', { class: 'ctx-art-x', text: a.title || a.id.slice(0, 8) }),
+            el('span', { class: 'ctx-art-t', text: a.at ? ago(a.at) : '' }),
         ])));
     }
 

--- a/web/public/assets/sidebar.css
+++ b/web/public/assets/sidebar.css
@@ -531,6 +531,18 @@
 .ctx-fact-v { color: var(--soa-fg); min-width: 0; overflow: hidden;
     text-overflow: ellipsis; white-space: nowrap; direction: rtl; text-align: left; }
 
+/* ARTIFACTS: one line per published thing, newest first. The row is the link —
+   a whole-row target beats a small anchor at this type size. */
+.ctx-arts { padding: 2px 6px 8px 12px; display: flex; flex-direction: column; gap: 1px;
+    min-height: 0; max-height: min(24vh, 200px); overflow-y: auto; }
+.ctx-art { display: grid; grid-template-columns: 1fr auto; gap: 8px; align-items: baseline;
+    padding: 2px 6px 2px 0; font-family: var(--font-mono); font-size: 10.5px;
+    color: var(--soa-fg); text-decoration: none; border-left: 2px solid transparent; }
+.ctx-art:hover { color: var(--soa-accent); border-left-color: var(--soa-accent); }
+.ctx-art:focus-visible { outline: 1px solid var(--soa-accent); outline-offset: 1px; }
+.ctx-art-x { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ctx-art-t { font-size: 8.5px; color: var(--soa-accent-dim); opacity: 0.7; }
+
 .ctx-steps { padding: 2px 12px 4px; display: flex; flex-direction: column; gap: 1px;
     max-height: min(30vh, 260px); overflow-y: auto; }
 .ctx-step { display: grid; grid-template-columns: auto 1fr auto; gap: 7px;

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -155,7 +155,7 @@
   <link rel="shortcut icon" href="/assets/New-icon-transparent.png?v=3" type="image/png">
   <link rel="apple-touch-icon" href="/assets/New-icon-transparent.png?v=3">
   <link rel="stylesheet" href="/assets/styles.css?v=90">
-  <link rel="stylesheet" href="/assets/sidebar.css?v=43">
+  <link rel="stylesheet" href="/assets/sidebar.css?v=44">
   <link rel="stylesheet" href="/assets/minimal.css?v=4">
   <link rel="stylesheet" href="/assets/liquid.css?v=10">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@5.3.0/css/xterm.css">
@@ -894,7 +894,7 @@ SOA_WEB_PASSWORD=hunter2 npm install &amp;&amp; npm start</pre>
   <script src="https://cdn.jsdelivr.net/npm/xterm@5.3.0/lib/xterm.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/xterm-addon-fit@0.8.0/lib/xterm-addon-fit.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/xterm-addon-web-links@0.9.0/lib/xterm-addon-web-links.js"></script>
-  <script type="module" src="/assets/app.js?v=149"></script>
+  <script type="module" src="/assets/app.js?v=150"></script>
   <script>
     // Cloudflare Web Analytics — loaded only when a token is configured (Vercel
     // env SOA_WEB_CF_ANALYTICS_TOKEN). Skipped on dev / self-host so localhost

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -894,7 +894,7 @@ SOA_WEB_PASSWORD=hunter2 npm install &amp;&amp; npm start</pre>
   <script src="https://cdn.jsdelivr.net/npm/xterm@5.3.0/lib/xterm.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/xterm-addon-fit@0.8.0/lib/xterm-addon-fit.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/xterm-addon-web-links@0.9.0/lib/xterm-addon-web-links.js"></script>
-  <script type="module" src="/assets/app.js?v=150"></script>
+  <script type="module" src="/assets/app.js?v=151"></script>
   <script>
     // Cloudflare Web Analytics — loaded only when a token is configured (Vercel
     // env SOA_WEB_CF_ANALYTICS_TOKEN). Skipped on dev / self-host so localhost


### PR DESCRIPTION
Builds on #7.

**ARTIFACTS band.** The canvas now shows what the session published, updated by
default — the daemon reads `claude.ai` artifact URLs out of the session's own
transcript, so a URL printed once lands on the canvas without anyone announcing
it. Newest first, click to open, title taken from the Artifact tool call when
it's there.

**The canvas is read-write.** `soa-ctx` is the agent's side of the panel the user
watches: `soa-ctx` prints the whole canvas, `soa-ctx step add|done|rm|clear`
edits NEXT STEPS, `soa-ctx artifact <url> [title]` registers one explicitly (new
`POST /api/context/artifacts`). Everything is scoped to the Claude session that
owns the cwd, so there is nothing to look up.

**CLAUDE.md** records the two workflows agents kept rediscovering: this CLI, and
how to bring a lost fleet back — one non-destructive call to
`/api/fleet/restore`, plus the two failure modes that made the last loss worse
(a `closedByUser` tombstone blocking boot self-heal, and `soa-restore-fleet`
needing a Fleet Manager entitlement the install didn't have).

The server half needs a daemon restart to go live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)