### PR TITLE
CI/CD: test every PR, cut releases on tags, and let the daemon update itself

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+# CI — every PR and every push to main.
+#
+# The daemon this repo builds runs unattended on someone's machine with a dozen
+# live agent sessions attached to it, and scripts/soa-selfupdate will pull a
+# green build onto that machine on its own. So "green" has to mean something:
+# the suite here is the same one the updater runs as its preflight, and a syntax
+# sweep catches the class of mistake that only shows up when the daemon boots.
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# Nothing here needs write access, and a PR from a fork should never get it.
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: test (node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ['20.x', '22.x']
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+
+      # node-pty compiles a native addon; ubuntu-latest already carries the
+      # toolchain, so a plain `npm ci` is enough.
+      - name: Install
+        run: npm ci
+
+      # A daemon that fails to parse takes the whole fleet down at boot, and no
+      # unit test covers a stray brace in a module that only loads on startup.
+      - name: Syntax sweep (server + node scripts)
+        run: |
+          set -euo pipefail
+          for f in server/src/*.js; do node --check "$f"; done
+          for f in scripts/*.js scripts/*.mjs; do [ -e "$f" ] || continue; node --check "$f"; done
+          # The extensionless CLIs are a mix of node and bash — check each with
+          # the interpreter its own shebang names.
+          for f in scripts/*; do
+            [ -f "$f" ] || continue
+            case "$(head -1 "$f")" in
+              *"env node"*) node --check "$f" ;;
+              *bash*|*sh)   bash -n "$f" ;;
+            esac
+          done
+
+      - name: Test
+        run: npm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,69 @@
+# Release — cut on a `v*` tag pushed to a commit that is already on main.
+#
+# This is the other half of the delivery path: the tag produces a GitHub Release,
+# and scripts/soa-selfupdate on the machine running the daemon tracks the newest
+# `v*` tag on its `release` channel. Tag → tested → released → the daemon picks it
+# up in its maintenance window. Nothing is published that did not pass the suite.
+#
+# Cutting one:
+#   git checkout main && git pull
+#   git tag -a v0.2.0 -m "v0.2.0" && git push origin v0.2.0
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # release notes are generated from history
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      # A tag is a promise that this code is safe to auto-deploy. Test it here
+      # too — the tagged commit may not be the one CI last saw on main.
+      - name: Test
+        run: npm test
+
+      # The package version is informational (the tag is the source of truth),
+      # but a mismatch usually means someone tagged the wrong commit — say so
+      # without failing the release.
+      - name: Version check
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          pkg="$(node -p "require('./package.json').version")"
+          if [ "$tag" != "$pkg" ]; then
+            echo "::warning::tag v$tag does not match package.json version $pkg"
+          fi
+
+      # Source tarball for installs that don't clone: same tree, no git, no
+      # node_modules (the daemon's own installer runs npm ci).
+      - name: Build source tarball
+        run: |
+          set -euo pipefail
+          name="soa-web-${GITHUB_REF_NAME}"
+          git archive --format=tar.gz --prefix="${name}/" -o "${name}.tar.gz" "${GITHUB_REF_NAME}"
+          shasum -a 256 "${name}.tar.gz" > "${name}.tar.gz.sha256"
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "${GITHUB_REF_NAME}" \
+            --generate-notes \
+            "soa-web-${GITHUB_REF_NAME}.tar.gz" \
+            "soa-web-${GITHUB_REF_NAME}.tar.gz.sha256"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,6 +314,47 @@ soa-browser screenshot out.jpg
 
 `soa-browser open|click|type|key|scroll|back|eval|url|screenshot`.
 
+## Shipping a change (CI/CD)
+
+Tests run in GitHub Actions on every PR and every push to `main`
+(`.github/workflows/ci.yml`: `npm ci`, a syntax sweep over `server/src` and the
+node CLIs, then `npm test` on node 20 + 22). `main` is protected — changes land
+through a PR, not a direct push.
+
+A release is cut by tagging a commit that is already on `main`:
+
+```bash
+git checkout main && git pull
+git tag -a v0.2.0 -m "v0.2.0" && git push origin v0.2.0
+```
+
+`.github/workflows/release.yml` re-runs the suite on the tagged commit, then
+publishes a GitHub Release with generated notes and a source tarball. Nothing is
+published that did not pass.
+
+**The daemon updates itself from those releases.** `scripts/soa-selfupdate`
+(launchd job `com.soa-web.selfupdate`, every 30 min) tracks the newest `v*` tag:
+
+```bash
+soa-selfupdate --check        # what's available, change nothing
+soa-selfupdate                # fetch + preflight + stage; restart only inside the window
+soa-selfupdate --now          # apply and restart immediately
+soa-selfupdate --channel main # track origin/main instead of releases
+```
+
+Five properties make it safe to leave running: it updates the checkout the LIVE
+daemon is running (read from the process's own command line, not guessed); it
+refuses to touch a dirty working tree; staged code must pass `node --check` on
+every server source **and** the full test suite before a restart is considered;
+restarts are windowed (`SOA_UPDATE_WINDOW`, default 03:00–05:00) because a
+restart respawns every tab's shell; and a restart that can't be verified rolls
+back to the previous commit and restarts again. Kill switch:
+`SOA_UPDATE_ENABLE=0`.
+
+For a change you want live **now**, `soa-deploy` is still the direct path
+(mirror → `kickstart -k` → prove the new pid is serving the new code). Static
+client files under `web/public/**` only need a reload.
+
 ## Deploy model
 
 The production instance is the **consolidated daemon**: launchd label

--- a/deploy/launchd/README.md
+++ b/deploy/launchd/README.md
@@ -75,3 +75,21 @@ launchctl bootout gui/$(id -u)/com.soa-web.server
 ```
 
 Logs: `~/.soa-web/logs/watchdog.log` (only written when it takes action).
+
+## `com.soa-web.selfupdate.plist` — automated backend updates
+
+The delivery end of CI/CD. Every 30 minutes `scripts/soa-selfupdate` checks the
+repo for a newer release (`v*` tag; `SOA_UPDATE_CHANNEL=main` tracks main
+instead), stages it, and preflights it — `node --check` on every server source
+plus the full test suite — before anything restarts.
+
+The restart is the disruptive part (every tab's shell respawns and auto-resumes),
+so it is **windowed**: `SOA_UPDATE_WINDOW`, default 03:00–05:00 local. Outside
+that window an update sits staged and the running daemon is untouched; force it
+with `soa-selfupdate --now`. If the restart can't be verified by `soa-deploy`
+(fresh pid, `/api/ping` green, start time after the newest source mtime), the
+previous commit is checked out and restarted, and you get a push notification.
+
+It refuses to touch a working tree that is dirty or ahead of the target, so a
+machine you also develop on is never clobbered. `SOA_UPDATE_ENABLE=0` disables
+it without unloading the job.

--- a/deploy/launchd/com.soa-web.selfupdate.plist
+++ b/deploy/launchd/com.soa-web.selfupdate.plist
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  SELF-UPDATE — runs scripts/soa-selfupdate every 30 min (1800s).
+
+  Delivery half of CI/CD: GitHub Actions tests every PR and publishes a release
+  on a `v*` tag; this pulls that release onto the machine running the daemon.
+
+  Safe to leave on. Fetch, preflight (node --check + the full test suite) and
+  staging happen on every tick, but the DISRUPTIVE part — the restart, which
+  respawns every tab's shell — only happens inside SOA_UPDATE_WINDOW. A failed
+  restart rolls back to the previous commit. A dirty working tree aborts the
+  update untouched, so a machine you develop on is never clobbered.
+
+  Knobs (edit below):
+    SOA_UPDATE_CHANNEL  release (newest v* tag, default) | main
+    SOA_UPDATE_WINDOW   local-time window in which restarts may happen
+    SOA_UPDATE_ENABLE   0 to disable without unloading the job
+    SOA_WEB_PORT        daemon port to health-check after the restart
+
+  Paths below assume the install at ~/.s0a-local/app — change them if the daemon
+  runs from a different checkout (soa-selfupdate itself reads the live process to
+  find the real one).
+
+  Load: launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.soa-web.selfupdate.plist
+  Run once by hand:  soa-selfupdate --check      (report only)
+                     soa-selfupdate --now        (apply + restart immediately)
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.soa-web.selfupdate</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/realsimon/.s0a-local/app/scripts/soa-selfupdate</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/realsimon/.s0a-local/app</string>
+
+    <key>RunAtLoad</key>
+    <false/>
+
+    <key>StartInterval</key>
+    <integer>1800</integer>
+
+    <key>AbandonProcessGroup</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>/Users/realsimon/.s0a-local/logs/selfupdate.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/realsimon/.s0a-local/logs/selfupdate.err.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/realsimon/.s0a-local/app/scripts</string>
+        <key>SOA_UPDATE_CHANNEL</key>
+        <string>release</string>
+        <key>SOA_UPDATE_WINDOW</key>
+        <string>03:00-05:00</string>
+        <key>SOA_UPDATE_ENABLE</key>
+        <string>1</string>
+        <key>SOA_WEB_PORT</key>
+        <string>4010</string>
+    </dict>
+</dict>
+</plist>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soa-web",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "Son of Anton, reimagined as a web app. Terminal sessions over WebSocket, TRON UI in the browser, zero desktop install.",
   "license": "GPL-3.0",

--- a/scripts/soa-deploy
+++ b/scripts/soa-deploy
@@ -120,11 +120,19 @@ if [ "$DRY_RUN" = 1 ]; then
     exit 0
 fi
 
-echo "mirroring server/src + scripts → $INSTALL_ROOT …"
-rsync -a "$DEV_ROOT/server/src/" "$INSTALL_ROOT/server/src/"
-rsync -a "$DEV_ROOT/scripts/"    "$INSTALL_ROOT/scripts/"
-chmod +x "$INSTALL_ROOT"/scripts/* 2>/dev/null || true
-echo "mirror done."
+# A self-hosted install runs the repo IN PLACE (DEV_ROOT == INSTALL_ROOT), e.g. an
+# install.sh checkout the daemon is launched from. There is nothing to mirror
+# there, and rsyncing a tree onto itself is a pointless risk — skip straight to
+# the restart, which is the part that actually matters.
+if [ "$(cd "$DEV_ROOT" && pwd -P)" = "$(cd "$INSTALL_ROOT" && pwd -P)" ]; then
+    echo "dev root IS the install root — nothing to mirror, restarting in place."
+else
+    echo "mirroring server/src + scripts → $INSTALL_ROOT …"
+    rsync -a "$DEV_ROOT/server/src/" "$INSTALL_ROOT/server/src/"
+    rsync -a "$DEV_ROOT/scripts/"    "$INSTALL_ROOT/scripts/"
+    chmod +x "$INSTALL_ROOT"/scripts/* 2>/dev/null || true
+    echo "mirror done."
+fi
 
 if [ "$RESTART" = 0 ]; then
     echo

--- a/scripts/soa-selfupdate
+++ b/scripts/soa-selfupdate
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+#
+# soa-selfupdate — keep the LIVE backend daemon on the latest published code.
+#
+# The delivery half of CI/CD. GitHub Actions tests every PR and cuts a release on
+# a `v*` tag; this is what pulls that release onto the machine actually running
+# the daemon, verifies it before it can hurt anything, restarts on the new code,
+# and rolls back if the restart doesn't come up clean.
+#
+# The five properties that make it safe to run unattended:
+#
+#   1. IT UPDATES THE CODE THE DAEMON IS ACTUALLY RUNNING. The install root is
+#      read from the live process's own command line, not guessed — updating a
+#      checkout the daemon never loads is the classic silent no-op.
+#   2. IT NEVER CLOBBERS LOCAL WORK. A dirty tree, a detached branch with local
+#      commits, or an unknown remote aborts the update (override with --force).
+#   3. IT PREFLIGHTS. Staged code must pass `node --check` on every server source
+#      AND the full test suite before a restart is even considered. Broken code
+#      never reaches a restart, so KeepAlive can't crash-loop on it.
+#   4. RESTARTS ARE WINDOWED. Fetch/verify happen any time; the disruptive part —
+#      the restart, which respawns every tab's shell — only happens inside the
+#      maintenance window, or when you ask for it with --now. Until then the
+#      update sits staged and the running daemon is untouched.
+#   5. IT ROLLS BACK. If soa-deploy can't prove a fresh, healthy daemon, the old
+#      commit is checked out and restarted, and you get told.
+#
+# Usage:
+#   soa-selfupdate                     # check + stage; restart only inside the window
+#   soa-selfupdate --check             # report what's available, change nothing
+#   soa-selfupdate --now               # apply and restart immediately
+#   soa-selfupdate --channel main      # track origin/main instead of release tags
+#   soa-selfupdate --window 03:00-05:00
+#   soa-selfupdate --dry-run           # print the plan, touch nothing
+#   soa-selfupdate --force             # proceed despite a dirty tree (last resort)
+#
+# Env: SOA_UPDATE_CHANNEL (release|main) · SOA_UPDATE_WINDOW (HH:MM-HH:MM) ·
+#      SOA_UPDATE_ENABLE=0 (kill switch) · SOA_WEB_INSTALL_ROOT · SOA_WEB_PORT
+#
+# Exit codes: 0 up to date / applied · 10 update available but not applied
+#             (staged, or --check) · 1 failed (rolled back if a restart was tried)
+
+set -euo pipefail
+
+CHANNEL="${SOA_UPDATE_CHANNEL:-release}"
+WINDOW="${SOA_UPDATE_WINDOW:-03:00-05:00}"
+PORT="${SOA_WEB_PORT:-4010}"
+LABEL="${SOA_UPDATE_LABEL:-app.s0a.web.local}"
+CHECK=0; NOW=0; DRY=0; FORCE=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --check)   CHECK=1; shift;;
+        --now)     NOW=1; shift;;
+        --dry-run) DRY=1; shift;;
+        --force)   FORCE=1; shift;;
+        --channel) CHANNEL="$2"; shift 2;;
+        --window)  WINDOW="$2"; shift 2;;
+        --port)    PORT="$2"; shift 2;;
+        --label)   LABEL="$2"; shift 2;;
+        -h|--help) sed -n '2,45p' "$0"; exit 0;;
+        *) echo "soa-selfupdate: unknown arg '$1'" >&2; exit 2;;
+    esac
+done
+
+log() { echo "$(date '+%Y-%m-%d %H:%M:%S') soa-selfupdate: $*"; }
+die() { log "ERROR: $*" >&2; exit 1; }
+
+[ "${SOA_UPDATE_ENABLE:-1}" = "1" ] || { log "disabled (SOA_UPDATE_ENABLE=0)"; exit 0; }
+
+# ── 1. where does the LIVE daemon run from? ───────────────────────────────────
+# Ask the process, not the filesystem: `node /path/to/server/src/index.js` names
+# the only checkout an update can possibly affect.
+resolve_install_root() {
+    if [ -n "${SOA_WEB_INSTALL_ROOT:-}" ]; then echo "$SOA_WEB_INSTALL_ROOT"; return; fi
+    local pid cmd entry
+    pid="$(launchctl print "gui/$(id -u)/${LABEL}" 2>/dev/null | awk -F'= ' '/^[[:space:]]*pid =/{print $2; exit}')"
+    if [ -n "${pid:-}" ]; then
+        cmd="$(ps -o command= -p "$pid" 2>/dev/null || true)"
+        entry="$(echo "$cmd" | tr ' ' '\n' | grep -m1 'server/src/index\.js' || true)"
+        if [ -n "$entry" ]; then (cd "$(dirname "$entry")/../.." && pwd -P); return; fi
+    fi
+    echo "$HOME/.soa-web"
+}
+
+ROOT="$(resolve_install_root)"
+[ -d "$ROOT/server/src" ] || die "no server/src under install root: $ROOT"
+[ -d "$ROOT/.git" ]       || die "install root is not a git checkout: $ROOT (nothing to update from)"
+cd "$ROOT"
+
+LOG_DIR="$ROOT/logs"; mkdir -p "$LOG_DIR" 2>/dev/null || true
+log "install root: $ROOT  ·  channel: $CHANNEL  ·  daemon: $LABEL (:$PORT)"
+
+# ── 2. refuse to touch a working tree that has anything of yours in it ────────
+DIRTY="$(git status --porcelain | head -5 || true)"
+if [ -n "$DIRTY" ] && [ "$FORCE" != 1 ]; then
+    log "working tree is dirty — refusing to update (nothing was touched):"
+    echo "$DIRTY" | sed 's/^/    /'
+    log "commit/stash it, or re-run with --force"
+    exit 1
+fi
+
+git fetch --quiet --tags --prune origin || die "git fetch failed"
+OLD_SHA="$(git rev-parse HEAD)"
+OLD_DESC="$(git describe --tags --always 2>/dev/null || echo "$OLD_SHA")"
+
+# ── 3. what should we be on? ─────────────────────────────────────────────────
+case "$CHANNEL" in
+    release)
+        # Newest semver tag on the remote. `-V` sorts v0.9.0 before v0.10.0.
+        TARGET_REF="$(git tag --list 'v[0-9]*' --sort=-v:refname | head -1)"
+        [ -n "$TARGET_REF" ] || { log "no v* release tags yet — nothing to track on the release channel"; exit 0; }
+        ;;
+    main)
+        TARGET_REF="origin/main"
+        ;;
+    *) die "unknown channel '$CHANNEL' (use release or main)";;
+esac
+TARGET_SHA="$(git rev-parse "$TARGET_REF^{commit}")"
+
+if [ "$TARGET_SHA" = "$OLD_SHA" ]; then
+    log "up to date ($OLD_DESC)"
+    exit 0
+fi
+
+# Ahead of / diverged from the target means this checkout is somebody's work
+# branch, not a deployment of the tracked line. Moving it would silently abandon
+# those commits — exactly the "never clobber local work" rule, and the reason it
+# is safe to leave this job running on a machine you also develop on.
+AHEAD="$(git rev-list --count "$TARGET_SHA..$OLD_SHA" 2>/dev/null || echo 0)"
+if [ "$AHEAD" -gt 0 ] && [ "$FORCE" != 1 ]; then
+    log "checkout is $AHEAD commit(s) ahead of $TARGET_REF (a work branch: $(git rev-parse --abbrev-ref HEAD))"
+    log "refusing to move it — nothing was touched. Use --force only if you mean to discard that."
+    exit 1
+fi
+
+BEHIND="$(git rev-list --count "$OLD_SHA..$TARGET_SHA" 2>/dev/null || echo '?')"
+log "update available: $OLD_DESC → $TARGET_REF ($BEHIND commit(s) ahead)"
+git log --oneline "$OLD_SHA..$TARGET_SHA" 2>/dev/null | head -8 | sed 's/^/    /'
+
+if [ "$CHECK" = 1 ] || [ "$DRY" = 1 ]; then
+    log "would: checkout $TARGET_REF → preflight (node --check + npm test) → $([ "$NOW" = 1 ] && echo 'restart now' || echo "restart inside $WINDOW")"
+    exit 10
+fi
+
+# ── 4. stage the new code ────────────────────────────────────────────────────
+LOCK_CHANGED=0
+git diff --quiet "$OLD_SHA" "$TARGET_SHA" -- package-lock.json package.json || LOCK_CHANGED=1
+
+rollback() {
+    log "ROLLING BACK to $OLD_DESC"
+    git checkout --quiet --force "$OLD_SHA" || log "rollback checkout FAILED — manual recovery needed at $ROOT"
+    # An `[ x ] && cmd` here would return 1 when the test is false and, under
+    # `set -e`, abort the rollback BEFORE the restart below — leaving the daemon
+    # down. A rollback path must not have a way to quit early.
+    if [ "$LOCK_CHANGED" = 1 ]; then
+        npm ci --omit=dev --silent || log "rollback npm ci failed"
+    fi
+    launchctl kickstart -k "gui/$(id -u)/${LABEL}" 2>/dev/null || true
+    command -v soa-notify >/dev/null 2>&1 && soa-notify "SoA update rolled back to $OLD_DESC — the new build did not come up" >/dev/null 2>&1 || true
+}
+
+log "staging $TARGET_REF …"
+git -c advice.detachedHead=false checkout --quiet --force "$TARGET_SHA" || die "checkout failed (tree untouched)"
+
+if [ "$LOCK_CHANGED" = 1 ]; then
+    log "dependencies changed — npm ci"
+    npm ci --omit=dev --silent || { rollback; die "npm ci failed on the new build"; }
+fi
+
+# ── 5. preflight: broken code must never reach a restart ─────────────────────
+log "preflight: syntax"
+for f in server/src/*.js; do
+    node --check "$f" >/dev/null 2>&1 || { rollback; die "syntax check failed: $f"; }
+done
+log "preflight: test suite"
+if ! npm test >"$LOG_DIR/selfupdate-test.log" 2>&1; then
+    tail -20 "$LOG_DIR/selfupdate-test.log" | sed 's/^/    /'
+    rollback
+    die "test suite failed on $TARGET_REF (see $LOG_DIR/selfupdate-test.log)"
+fi
+log "preflight: green"
+
+# ── 6. restart — the disruptive part, so it is windowed ──────────────────────
+in_window() {
+    local start end now
+    start="${WINDOW%%-*}"; end="${WINDOW##*-}"
+    now="$(date +%H%M)"
+    start="${start/:/}"; end="${end/:/}"
+    if [ "$start" -le "$end" ]; then
+        [ "$now" -ge "$start" ] && [ "$now" -lt "$end" ]
+    else
+        # A window that wraps midnight, e.g. 23:00-02:00.
+        [ "$now" -ge "$start" ] || [ "$now" -lt "$end" ]
+    fi
+}
+
+if [ "$NOW" != 1 ] && ! in_window; then
+    log "staged $TARGET_REF — the running daemon is still on the old code."
+    log "restart deferred to the maintenance window ($WINDOW); force it with: soa-selfupdate --now"
+    exit 10
+fi
+
+log "restarting the daemon onto $TARGET_REF (tabs respawn and auto-resume)…"
+if ! soa-deploy --dev-root "$ROOT" --install-root "$ROOT" --port "$PORT" --label "$LABEL"; then
+    rollback
+    die "restart could not be verified — rolled back to $OLD_DESC"
+fi
+
+NEW_DESC="$(git describe --tags --always 2>/dev/null || git rev-parse --short HEAD)"
+log "updated: $OLD_DESC → $NEW_DESC"
+command -v soa-notify >/dev/null 2>&1 && soa-notify "SoA backend updated to $NEW_DESC and restarted clean" >/dev/null 2>&1 || true

--- a/scripts/soa-selfupdate
+++ b/scripts/soa-selfupdate
@@ -143,11 +143,15 @@ if [ "$CHECK" = 1 ] || [ "$DRY" = 1 ]; then
 fi
 
 # ── 4. stage the new code ────────────────────────────────────────────────────
+# Did we get as far as bouncing the daemon? A preflight failure must revert the
+# code and stop — restarting a daemon that is running fine on the OLD code would
+# turn a caught problem into an outage.
+RESTARTED=0
 LOCK_CHANGED=0
 git diff --quiet "$OLD_SHA" "$TARGET_SHA" -- package-lock.json package.json || LOCK_CHANGED=1
 
 rollback() {
-    log "ROLLING BACK to $OLD_DESC"
+    log "reverting to $OLD_DESC$([ "$RESTARTED" = 1 ] && echo ' and restarting' || echo ' (daemon was never restarted)')"
     git checkout --quiet --force "$OLD_SHA" || log "rollback checkout FAILED — manual recovery needed at $ROOT"
     # An `[ x ] && cmd` here would return 1 when the test is false and, under
     # `set -e`, abort the rollback BEFORE the restart below — leaving the daemon
@@ -155,8 +159,13 @@ rollback() {
     if [ "$LOCK_CHANGED" = 1 ]; then
         npm ci --omit=dev --silent || log "rollback npm ci failed"
     fi
-    launchctl kickstart -k "gui/$(id -u)/${LABEL}" 2>/dev/null || true
-    command -v soa-notify >/dev/null 2>&1 && soa-notify "SoA update rolled back to $OLD_DESC — the new build did not come up" >/dev/null 2>&1 || true
+    if [ "$RESTARTED" = 1 ]; then
+        # We bounced it onto a build that didn't come up — bounce it back.
+        launchctl kickstart -k "gui/$(id -u)/${LABEL}" 2>/dev/null || true
+        command -v soa-notify >/dev/null 2>&1 && soa-notify "SoA update rolled back to $OLD_DESC — the new build did not come up" >/dev/null 2>&1 || true
+    else
+        command -v soa-notify >/dev/null 2>&1 && soa-notify "SoA update to $TARGET_REF failed preflight — daemon untouched, still on $OLD_DESC" >/dev/null 2>&1 || true
+    fi
 }
 
 log "staging $TARGET_REF …"
@@ -201,6 +210,7 @@ if [ "$NOW" != 1 ] && ! in_window; then
 fi
 
 log "restarting the daemon onto $TARGET_REF (tabs respawn and auto-resume)…"
+RESTARTED=1
 if ! soa-deploy --dev-root "$ROOT" --install-root "$ROOT" --port "$PORT" --label "$LABEL"; then
     rollback
     die "restart could not be verified — rolled back to $OLD_DESC"


### PR DESCRIPTION
There was no CI in this repo, and the only route onto the machine running the
daemon was `soa-deploy` by hand. Three pieces close that loop.

**CI** — `npm ci` + `npm test` on node 20 and 22 for every PR and every push to
main, plus a syntax sweep over `server/src` and the node CLIs. A daemon that
fails to parse takes the whole fleet down at boot, and no unit test covers a
stray brace in a module that only loads on startup. (163 tests, ~1.3s.)

**Releases** — a `v*` tag re-runs the suite on the tagged commit and publishes a
GitHub Release with generated notes and a source tarball. Nothing is published
that did not pass.

**`scripts/soa-selfupdate`** — the delivery end, as a launchd job every 30 min
tracking the newest `v*` tag. What makes it safe to leave running:

- it updates the checkout the **live daemon** runs, read from the process's own
  command line — updating a checkout the daemon never loads is the classic
  silent no-op;
- it refuses a dirty tree or a checkout ahead of the target, so a machine you
  also develop on is never clobbered;
- staged code must pass `node --check` on every server source **and** the full
  suite before a restart is considered;
- restarts are **windowed** (default 03:00–05:00) because a restart respawns
  every tab's shell — outside the window the update sits staged and the running
  daemon is untouched;
- a restart `soa-deploy` can't verify rolls back to the previous commit; a
  *preflight* failure reverts the code and leaves the daemon alone.

`soa-deploy` learns to skip the mirror when the dev root is the install root — a
self-hosted checkout the daemon runs in place, which is what the updater drives.

Verified against a throwaway clone: dirty-tree refusal, work-branch refusal,
update-available report, preflight failure (checkout reverted, daemon pid
unchanged), and green preflight staged with the restart deferred (pid unchanged).

Merge order: this one before tagging, since the release workflow has to exist on
main for the tag to build anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)