### PR TITLE
fix(timemachine): record tab cwds on HELLO, not only on SNAPSHOT

### DIFF
--- a/web/public/assets/app.js
+++ b/web/public/assets/app.js
@@ -844,7 +844,18 @@ class Shell {
         this._updateGraveyard(graveyard);
         this._updateDeviceCount(connectedDevices);
         if (Array.isArray(tabs) && tabs.length) {
-            for (const t of tabs) this._ensureTab(t.id, t.title);
+            // HELLO carries each tab's cwd and memory (tabManager.list()), and
+            // the Time Machine NEEDS the cwd: a snapshot with no cwds can only
+            // replay into tabs that are still open, never rebuild a fleet that
+            // is gone — which is exactly what "view only" on every snapshot
+            // meant. _onSnapshot recorded both; HELLO, the one message a fresh
+            // page load is guaranteed to receive, dropped them, so a tab whose
+            // cwd never changed stayed unrecorded for the life of the page.
+            for (const t of tabs) {
+                this._ensureTab(t.id, t.title);
+                if (t.mem != null) this._tabMem.set(t.id, t.mem);
+                if (t.cwd) this._tabCwd.set(t.id, t.cwd);
+            }
             // Queue each tab's scrollback instead of writing it straight
             // into xterm. Writing before fit means writing at the default
             // 80×24 — any absolute-column ANSI in the stream lands at the


### PR DESCRIPTION
Every Time Machine row said `view only`, so a restore could only replay scrollback into tabs that were still open and `rebuilt 0` was the best it could ever report.

`_tabCwd` was filled in from the WS `SNAPSHOT` message only. A page load that never saw a tab open, close or change directory therefore recorded no cwds, and every snapshot it took was unrebuildable. `HELLO` already carries `cwd` and `mem` per tab (`tabManager.list()`) — it just wasn't read.

Verified against the live dashboard: a snapshot taken after the fix lists **19 restorable** where the ones before it say **view only**.