### PR TITLE
fix(context): keep the prompt gutter out of the clipboard

### DIFF
--- a/web/public/assets/sidebar.css
+++ b/web/public/assets/sidebar.css
@@ -535,7 +535,13 @@
     padding: 5px 12px 5px 4px; border-left: 2px solid transparent; }
 .ctx-turn.latest { border-left-color: var(--soa-accent);
     background: rgba(var(--soa-accent-rgb), 0.045); }
-.ctx-turn-m { display: flex; flex-direction: column; align-items: flex-end; gap: 1px; padding-top: 1px; }
+/* The turn number and its age are chrome, not content. Selecting a run of
+   prompts to paste elsewhere used to swallow them, so the clipboard came out as
+   `…(down` / `22` / `3d` / `change bracket to (down xx %)` — the gutter
+   interleaved line by line with the text, unreadable at the other end. Excluding
+   the meta column from selection leaves the prompts themselves, one per line. */
+.ctx-turn-m { display: flex; flex-direction: column; align-items: flex-end; gap: 1px; padding-top: 1px;
+    user-select: none; -webkit-user-select: none; }
 .ctx-turn-n { font-family: var(--font-mono); font-size: 9px; color: var(--soa-accent-dim);
     font-variant-numeric: tabular-nums; }
 .ctx-turn.latest .ctx-turn-n { color: var(--soa-accent); }


### PR DESCRIPTION
Copying prompts out of the CONTEXT panel pulled the turn number and relative age in with the text. Recovered verbatim from `~/.claude/history.jsonl`, a paste of that clipboard looked like:

```
…(down\r\r22\r3d\rchange bracket to (down xx %)\r\r23\r3h\ramazing - help me to consider…
```

`.ctx-turn-m` (the number + age column) is chrome, not content, so it is now excluded from selection.

Verified in a live dashboard — selecting all 40 rendered turns now yields the prompts alone, one per line:

```
give me the pr link when it's ready for review

why are you changin the title? flip it back to fix(website):show preview…
```