### PR TITLE
feat: tell people how to get their terminals back

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ Can this replace the desktop app on the web? **Yes, functionally.** The scary pa
 - **Auth.** `SOA_WEB_AUTH=shared` with `SOA_WEB_PASSWORD` gates access behind a signed HttpOnly cookie. `none` delegates to an upstream proxy (Cloudflare Access, tailscale funnel, oauth2_proxy). `open` is localhost-only.
 - **Claude Code, etc.** Any CLI you want to use runs server-side inside the PTY. Install it on the host; your browser is just the glass.
 
+## If it stops responding
+
+Terminals live on the server, not in the browser tab, and every tab's directory
+and scrollback is on disk — so a dark dashboard is almost never lost work.
+**[RECOVERY.md](RECOVERY.md)** walks through it from "wait a second" to
+rebuilding the fleet by hand. The dashboard shows the same steps itself, in a
+panel that appears once the connection has been down for about eight seconds.
+
 ## Running it
 
 ```bash

--- a/RECOVERY.md
+++ b/RECOVERY.md
@@ -1,0 +1,185 @@
+# If the dashboard goes dark
+
+**Nothing is lost.** Your terminals do not live in the browser tab — they are
+real shells running on your Mac, and every tab's directory and scrollback is
+written to disk. A blank dashboard almost always means one thing: the page can't
+reach the server for a moment. The shells are still there.
+
+This page is the whole recovery, from "wait a second" to "rebuild the fleet by
+hand". Work down it in order and stop as soon as the dashboard comes back.
+
+The dashboard shows you most of this itself: once the connection has been down
+for about eight seconds a panel appears in the bottom-right with these steps and
+a copy button on each command. This file is the longer version, and the one you
+can still read when there is no dashboard to open.
+
+---
+
+## 0. What just happened
+
+| What you see | What it means |
+|---|---|
+| `disconnected` in red, bottom-right | The page lost its WebSocket. The server may be fine. |
+| Terminals frozen but visible | You are looking at the last frame the page received. |
+| Dashboard loads but has one tab | The server restarted and hasn't re-adopted your tabs yet. |
+| Browser can't open the page at all | The server is genuinely down. |
+
+## 1. Wait about a minute
+
+macOS supervises the server and restarts it on its own. The page retries on a
+backoff and reconnects the moment the server answers — you do not have to reload
+anything.
+
+The panel in the dashboard counts the retries out loud (`attempt 3, next try in
+4s`) so you can see it is still working rather than guessing.
+
+## 2. Ask whether the server is up
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:4010/
+```
+
+- **`200`** — the server is healthy and only your browser tab is stuck. Reload
+  the page.
+- **`000` or a hang** — nothing is listening. Continue to step 3.
+
+## 3. Start it again
+
+```bash
+launchctl kickstart -k gui/$(id -u)/app.s0a.web.local
+```
+
+Run this in the macOS **Terminal** app, not in a SoA tab — the SoA tabs are
+children of the very process you are restarting.
+
+Give it ten seconds, then reload the dashboard. Tabs and the public tunnel URL
+re-adopt themselves; the tunnel address stays the same across restarts.
+
+If `launchctl` says the service is not loaded:
+
+```bash
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/app.s0a.web.local.plist
+```
+
+## 4. Tabs missing after it comes back
+
+```bash
+curl -sX POST http://127.0.0.1:4010/api/fleet/restore \
+     -H 'content-type: application/json' -d '{}'
+```
+
+This is the same thing the dashboard's **Time Machine → Restore** button calls.
+It is **non-destructive: it only ever opens tabs, never closes one**, so running
+it twice is safe — the second run comes back with an empty `opened` and skips
+everything already live.
+
+It picks the richest surviving record of your fleet, drops any entry whose
+directory no longer exists, skips directories that are already open (counting
+duplicates, so three tabs on one repo restore as three tabs), opens the rest,
+and resumes each one's Claude conversation with its own transcript.
+
+A healthy response looks like:
+
+```json
+{"ok":true,"from":"lastgood","opened":[...],"skipped":[...]}
+```
+
+`opened` and `skipped` are lists, so `opened` empty and `skipped` holding every
+directory means there was nothing left to do — the fleet is already whole.
+
+`from` tells you which record it used, in order of preference:
+
+| Source | What it is |
+|---|---|
+| `tabs.json` | The live tab list, written continuously. |
+| `lastgood` | A protected copy, only replaced by a known-good list. |
+| `tabs.json.bak-…` | Rolling backups, newest first. |
+| `scrollback` | Last resort: the directories found inside saved scrollback. |
+
+## 5. Nothing recovered
+
+Everything lives in the state directory — check it before assuming the state is
+gone:
+
+```bash
+ls -la ~/.s0a-local/state
+```
+
+You are looking for `tabs.json`, `tabs.json.lastgood`, a row of
+`tabs.json.bak-*` files, and `scrollback.json`. If those exist, your fleet is
+recoverable and step 4 should have worked.
+
+One thing that legitimately blocks recovery: a **`closedByUser` tombstone** in
+`tabs.json`. The server writes it when a session deliberately closes its last
+tab, and start-up recovery honours that intent instead of second-guessing you.
+If your fleet is down and `tabs.json` holds a single tab, check for that flag
+before concluding the state is lost.
+
+To restore from a specific backup by hand:
+
+```bash
+cd ~/.s0a-local/state
+cp tabs.json tabs.json.before-manual-restore     # keep an escape hatch
+cp tabs.json.bak-2026-09-07-2110 tabs.json       # pick the one you want
+launchctl kickstart -k gui/$(id -u)/app.s0a.web.local
+```
+
+## 6. Read the logs
+
+```bash
+tail -50 ~/.s0a-local/logs/err.log
+tail -50 ~/.s0a-local/logs/out.log
+```
+
+`err.log` is where a crash on start-up will say why — a port already in use, a
+bad config file, a missing dependency after an update.
+
+To see whether the server is running at all and which code it is running:
+
+```bash
+ps -axo pid=,command= | grep '[s]erver/src/index.js'
+```
+
+The path in that output is the checkout actually being served, which is worth
+knowing before you edit anything expecting it to take effect.
+
+---
+
+## Things that are safe, and things that are not
+
+**Safe, any time:**
+
+- Reloading the dashboard. Terminals are server-side; the page is only a view.
+- `POST /api/fleet/restore`. It only opens tabs.
+- Restarting the server with `launchctl kickstart`. Tabs and the tunnel
+  re-adopt.
+
+**Not safe:**
+
+- Deleting anything in `~/.s0a-local/state`. That is the fleet.
+- Restarting the server from inside a SoA tab. Use the macOS Terminal app.
+- Restoring an old Time Machine snapshot to fix a *display* problem. Restore
+  replays saved scrollback into open tabs, which can re-arm terminal modes that
+  were captured in it.
+
+## Quick reference
+
+```bash
+# is it up?
+curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:4010/
+
+# restart it
+launchctl kickstart -k gui/$(id -u)/app.s0a.web.local
+
+# bring the tabs back
+curl -sX POST http://127.0.0.1:4010/api/fleet/restore \
+     -H 'content-type: application/json' -d '{}'
+
+# what does it say?
+tail -50 ~/.s0a-local/logs/err.log
+```
+
+Paths and the port above are this install's defaults: port `4010`, launchd label
+`app.s0a.web.local`, state in `~/.s0a-local/state`. If yours differ, the
+dashboard's own recovery panel fills in the right values for you — it builds
+each command from the address you are actually connected to.

--- a/web/public/assets/app.js
+++ b/web/public/assets/app.js
@@ -810,6 +810,8 @@ class Shell {
             document.fonts.ready.then(() => this._fitActive()).catch(() => {});
         }
 
+        this._initRecovery();
+
         bridge.addEventListener('hello',     e => this._onHello(e.detail));
         bridge.addEventListener('replay',    e => this._onReplay(e.detail));
         bridge.addEventListener('snapshot',  e => this._onSnapshot(e.detail));
@@ -827,7 +829,8 @@ class Shell {
         bridge.addEventListener('unauthorized', () => { location.reload(); });
     }
 
-    _onStatus({ state }) {
+    _onStatus({ state, attempt, retryIn }) {
+        this._updateRecovery(state, attempt, retryIn);
         const s = $('#status-conn');
         s.className = state === 'open' ? 'ok' : state === 'connecting' ? 'warn' : 'err';
         const key = `status.${state}`;
@@ -838,6 +841,87 @@ class Shell {
             if (state === 'open')   this.audio.play('granted');
         }
         this._prevConnState = state;
+    }
+
+    // ── Recovery panel ──────────────────────────────────────────────────
+    // Losing the daemon is the most alarming thing this UI can do to someone
+    // who does not know what a daemon is, and until now it said so in one red
+    // word in the status bar. These two methods own the panel that takes that
+    // moment over. It is deliberately slow to appear: launchd usually restarts
+    // the daemon within seconds, and a page that panics faster than the system
+    // heals teaches people to distrust a working recovery.
+    _initRecovery() {
+        const box = $('#recovery');
+        if (!box) return;
+        // Commands must point at THIS machine even when the page was opened
+        // through the public tunnel — a tunnel URL is exactly what stops
+        // resolving when the daemon dies, so it is useless in a recovery step.
+        const local = /^(localhost|127\.0\.0\.1|\[::1\])$/.test(location.hostname);
+        const port = (local && location.port) || '4010';
+        const origin = `http://127.0.0.1:${port}`;
+        const cmds = {
+            health:  `curl -s -o /dev/null -w '%{http_code}\\n' ${origin}/`,
+            kick:    'launchctl kickstart -k gui/$(id -u)/app.s0a.web.local',
+            restore: `curl -sX POST ${origin}/api/fleet/restore -H 'content-type: application/json' -d '{}'`,
+        };
+        for (const el of box.querySelectorAll('code[data-cmd]')) el.textContent = cmds[el.dataset.cmd] || '';
+        for (const btn of box.querySelectorAll('.recovery-copy')) {
+            btn.addEventListener('click', async () => {
+                const text = cmds[btn.dataset.copy];
+                if (!text) return;
+                try { await navigator.clipboard.writeText(text); } catch (_) { return; }
+                btn.dataset.copied = '1';
+                btn.textContent = 'Copied';
+                setTimeout(() => { delete btn.dataset.copied; btn.textContent = 'Copy'; }, 1600);
+            });
+        }
+        $('#recovery-close').addEventListener('click', () => {
+            this._recoveryDismissed = true;
+            box.hidden = true;
+        });
+        // Dismissing it should not be a one-way door: the red status word is
+        // the handle that brings it back.
+        const conn = $('#status-conn');
+        if (conn) conn.addEventListener('click', () => {
+            if (!conn.classList.contains('err')) return;
+            this._recoveryDismissed = box.hidden ? false : true;
+            box.hidden = !box.hidden;
+        });
+    }
+
+    _updateRecovery(state, attempt, retryIn) {
+        const box = $('#recovery');
+        if (!box) return;
+        const SHOW_AFTER_MS = 8000;    // below this, waiting is the whole answer
+        const STUCK_AFTER_MS = 45000;  // above this, waiting has visibly failed
+
+        if (state === 'open') {
+            box.hidden = true;
+            this._recoveryDown = null;
+            this._recoveryDismissed = false;
+            if (this._recoveryTick) { clearInterval(this._recoveryTick); this._recoveryTick = null; }
+            return;
+        }
+        if (state === 'closed') {
+            if (!this._recoveryDown) this._recoveryDown = Date.now();
+            this._recoveryNext = retryIn ? Date.now() + retryIn : null;
+            this._recoveryAttempt = attempt || this._recoveryAttempt || 1;
+        }
+        if (!this._recoveryDown) return;
+
+        const paint = () => {
+            const downFor = Date.now() - this._recoveryDown;
+            if (!this._recoveryDismissed && downFor >= SHOW_AFTER_MS) box.hidden = false;
+            box.dataset.stage = downFor >= STUCK_AFTER_MS ? 'stuck' : 'waiting';
+            const pulse = $('#recovery-pulse');
+            if (!pulse) return;
+            const left = this._recoveryNext ? Math.max(0, Math.round((this._recoveryNext - Date.now()) / 1000)) : 0;
+            pulse.textContent = !this._recoveryNext || left === 0
+                ? `Trying to reconnect — attempt ${this._recoveryAttempt}`
+                : `Reconnecting — attempt ${this._recoveryAttempt}, next try in ${left}s`;
+        };
+        paint();
+        if (!this._recoveryTick) this._recoveryTick = setInterval(paint, 1000);
     }
 
     _onHello({ tabs, activeId, replay, graveyard, connectedDevices }) {

--- a/web/public/assets/bridge.js
+++ b/web/public/assets/bridge.js
@@ -45,6 +45,7 @@ export class Bridge extends EventTarget {
 
         ws.addEventListener('open', () => {
             this.backoff = 500;
+            this.attempts = 0;
             this._emit('status', { state: 'open' });
             this._ping = setInterval(() => this.send(MSG.PING, { ts: Date.now() }), 20_000);
         });
@@ -58,7 +59,16 @@ export class Bridge extends EventTarget {
         ws.addEventListener('close', ev => {
             this._clearPing();
             this.ws = null;
-            this._emit('status', { state: 'closed', code: ev.code });
+            // Report the retry we are about to make, not just the failure. A UI
+            // that can say "attempt 3, next try in 4s" turns a silent outage
+            // into something visibly still working on your behalf.
+            const willRetry = !this.closed && ev.code !== 1008 && ev.code !== 4401;
+            this.attempts = (this.attempts || 0) + 1;
+            this._emit('status', {
+                state: 'closed', code: ev.code,
+                attempt: this.attempts,
+                retryIn: willRetry ? this.backoff : null,
+            });
             if (this.closed) return;
             if (ev.code === 1008 || ev.code === 4401) {
                 // 1008 = policy violation / 4401 = our custom "relogin please"

--- a/web/public/assets/sidebar.css
+++ b/web/public/assets/sidebar.css
@@ -650,3 +650,110 @@ body.ctx-resizing * { cursor: inherit !important; }
 @media (max-width: 640px) {
     .ctx-pull { min-height: 64px; padding: 8px 0 9px; gap: 6px; font-size: 8px; }
 }
+
+/* ── Recovery panel ─────────────────────────────────────────────────────
+   The moment the daemon stops answering, the only feedback used to be the word
+   "disconnected" going red in the status bar — accurate, and no help at all to
+   someone who does not know what a daemon is. This panel takes that moment over.
+
+   Two decisions shape it. It is NOT a modal: the terminals behind it still hold
+   the work you were reading, and dimming the screen to make a point would take
+   that away. And it ESCALATES — for the first stretch it shows only the live
+   reconnect countdown, because launchd usually wins that race on its own and
+   four terminal commands are the wrong thing to put in front of a worried
+   person. Only once waiting has visibly failed do the rungs come up to full
+   contrast. The number on each rung is the order you should actually try them
+   in, which is the only reason it is numbered. */
+.recovery {
+    position: absolute; right: 14px; bottom: 38px; z-index: 40;
+    width: min(400px, calc(100vw - 28px)); max-height: calc(100% - 56px);
+    overflow-y: auto; overscroll-behavior: contain;
+    padding: 15px 16px 14px;
+    background: var(--soa-bg-panel);
+    border: 1px solid var(--soa-yellow); border-radius: 6px;
+    box-shadow: 0 14px 40px rgba(0, 0, 0, 0.45);
+    color: var(--soa-fg);
+    animation: recovery-in 220ms ease both;
+}
+@keyframes recovery-in { from { opacity: 0; transform: translateY(8px); } }
+@media (prefers-reduced-motion: reduce) { .recovery { animation: none; } }
+
+.recovery-head { display: flex; align-items: baseline; justify-content: space-between; gap: 10px; }
+.recovery-head h2 {
+    margin: 0; font-family: var(--font-display); font-size: 13px;
+    letter-spacing: 0.14em; text-transform: uppercase; color: var(--soa-yellow);
+}
+.recovery-close {
+    background: none; border: none; padding: 2px 4px; cursor: pointer; line-height: 1;
+    font-size: 12px; color: var(--soa-accent-dim);
+}
+.recovery-close:hover { color: var(--soa-accent); }
+
+/* The one line that matters most, so it is the one line that is not styled like
+   chrome: sentence case, normal weight, readable size. */
+.recovery-lead { margin: 9px 0 0; font-size: 12.5px; line-height: 1.5; }
+
+.recovery-pulse {
+    margin: 10px 0 0; padding: 7px 9px;
+    font-family: var(--font-mono); font-size: 10.5px; letter-spacing: 0.04em;
+    color: var(--soa-accent);
+    background: rgba(var(--soa-accent-rgb), 0.07);
+    border-left: 2px solid var(--soa-accent-dim); border-radius: 0 3px 3px 0;
+}
+
+.recovery-steps { list-style: none; margin: 13px 0 0; padding: 0; }
+.recovery-step {
+    display: grid; grid-template-columns: 20px 1fr; gap: 9px;
+    padding: 10px 0; border-top: 1px solid var(--soa-line-soft);
+}
+.recovery-step:first-child { border-top: none; padding-top: 4px; }
+.recovery-num {
+    font-family: var(--font-mono); font-size: 10px; line-height: 1.6;
+    color: var(--soa-accent-dim); text-align: right;
+}
+/* Grid and flex children default to min-content width, and a `white-space: pre`
+   command is very wide — without this the track grows to fit the longest curl
+   and pushes its own Copy button off the panel. */
+.recovery-body { min-width: 0; }
+.recovery-body h3 {
+    margin: 0 0 4px; font-size: 11.5px; font-weight: 600; letter-spacing: 0.01em;
+}
+.recovery-body p { margin: 4px 0 0; font-size: 11.5px; line-height: 1.45; opacity: 0.82; }
+
+/* While waiting is still the right advice, the manual rungs stay legible but
+   quiet — present if you go looking, not shouting over step 1. */
+.recovery[data-stage="waiting"] .recovery-step[data-rung="2"],
+.recovery[data-stage="waiting"] .recovery-step[data-rung="3"],
+.recovery[data-stage="waiting"] .recovery-step[data-rung="4"] { opacity: 0.42; }
+.recovery[data-stage="stuck"] .recovery-step { opacity: 1; transition: opacity 400ms ease; }
+
+.recovery-cmd {
+    display: flex; align-items: stretch; gap: 6px; margin-top: 5px;
+}
+.recovery-cmd code {
+    flex: 1 1 auto; min-width: 0; overflow-x: auto; white-space: pre;
+    padding: 6px 8px; font-family: var(--font-mono); font-size: 10px; line-height: 1.4;
+    background: var(--soa-bg); border: 1px solid var(--soa-line); border-radius: 3px;
+    color: var(--soa-accent);
+}
+.recovery-copy {
+    flex: 0 0 auto; padding: 0 9px; cursor: pointer;
+    font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.1em; text-transform: uppercase;
+    background: none; border: 1px solid var(--soa-line); border-radius: 3px;
+    color: var(--soa-accent-dim);
+}
+.recovery-copy:hover { color: var(--soa-accent); border-color: var(--soa-accent-dim); }
+.recovery-copy[data-copied] { color: var(--soa-accent); border-color: var(--soa-accent); }
+
+.recovery-foot {
+    margin: 12px 0 0; padding-top: 10px; border-top: 1px solid var(--soa-line-soft);
+    font-size: 10.5px; line-height: 1.5; color: var(--soa-accent-dim);
+}
+.recovery-foot code { font-family: var(--font-mono); font-size: 10px; color: var(--soa-fg); }
+
+/* The status word is the handle for bringing the panel back after dismissing it. */
+#status-conn.err { cursor: pointer; text-decoration: underline dotted; }
+
+@media (max-width: 640px) {
+    .recovery { right: 8px; left: 8px; bottom: 30px; width: auto; }
+}

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -881,6 +881,69 @@ SOA_WEB_PASSWORD=hunter2 npm install &amp;&amp; npm start</pre>
         <span class="ctx-pull-chev" aria-hidden="true"></span>
         <span class="ctx-pull-label" aria-hidden="true">CTX</span>
       </button>
+      <!-- Shown only when the WebSocket has been down long enough to worry
+           about. Everything it needs is already in the page, so it still
+           renders with the daemon completely gone. -->
+      <section id="recovery" class="recovery" data-stage="waiting" hidden
+               role="status" aria-live="polite" aria-labelledby="recovery-title">
+        <header class="recovery-head">
+          <h2 id="recovery-title">Can't reach the server</h2>
+          <button id="recovery-close" class="recovery-close" aria-label="Hide this panel">✕</button>
+        </header>
+        <p class="recovery-lead">Your terminals are still running on this Mac. This page lost its
+          connection to them — nothing has been closed and nothing has been deleted.</p>
+        <p id="recovery-pulse" class="recovery-pulse">Reconnecting…</p>
+
+        <ol class="recovery-steps">
+          <li class="recovery-step" data-rung="1">
+            <span class="recovery-num">1</span>
+            <div class="recovery-body">
+              <h3>Give it a minute</h3>
+              <p>macOS restarts the server on its own. This page reconnects by itself the
+                moment it answers — you do not have to do anything.</p>
+            </div>
+          </li>
+          <li class="recovery-step" data-rung="2">
+            <span class="recovery-num">2</span>
+            <div class="recovery-body">
+              <h3>Ask if it is up</h3>
+              <div class="recovery-cmd">
+                <code data-cmd="health"></code>
+                <button class="recovery-copy" data-copy="health">Copy</button>
+              </div>
+              <p><code>200</code> means the server is fine and only this page is stuck: reload it.</p>
+            </div>
+          </li>
+          <li class="recovery-step" data-rung="3">
+            <span class="recovery-num">3</span>
+            <div class="recovery-body">
+              <h3>Start it again</h3>
+              <div class="recovery-cmd">
+                <code data-cmd="kick"></code>
+                <button class="recovery-copy" data-copy="kick">Copy</button>
+              </div>
+              <p>Paste it into the macOS Terminal app. Your tabs come back with the server.</p>
+            </div>
+          </li>
+          <li class="recovery-step" data-rung="4">
+            <span class="recovery-num">4</span>
+            <div class="recovery-body">
+              <h3>Tabs missing once it is back</h3>
+              <div class="recovery-cmd">
+                <code data-cmd="restore"></code>
+                <button class="recovery-copy" data-copy="restore">Copy</button>
+              </div>
+              <p>This only ever opens tabs. It never closes one, so it is safe to run twice.</p>
+            </div>
+          </li>
+        </ol>
+
+        <p class="recovery-foot">Your tabs and scrollback are written to disk, not held in this
+          page: <code id="recovery-statedir">~/.s0a-local/state</code> keeps <code>tabs.json</code>,
+          a protected <code>.lastgood</code> copy, rolling backups and <code>scrollback.json</code>.
+          Full guide: <code>RECOVERY.md</code> in the repo.</p>
+      </section>
+
       <div class="status-bar">
         <span id="status-session">—</span>
         <span id="status-tabs" data-i18n="status.tabs_other" data-i18n-vars='{"n":0}'>0 tabs</span>


### PR DESCRIPTION
When the daemon goes away the dashboard said so in one red word in the status bar. Accurate, and no help at all to someone who does not know what a daemon is.

**In the dashboard** — a recovery panel that takes the moment over:

- **Holds back for 8s.** launchd usually restarts the daemon before then, and a page that panics faster than the system heals teaches people to distrust a working recovery.
- **Counts the retries out loud** — `Reconnecting — attempt 3, next try in 4s`. The scary part of an outage is silence; this makes the recovery visible. `bridge.js` now reports `attempt` and `retryIn` on the status event, which is what makes that honest.
- **Escalates.** Until 45s the manual steps sit at low contrast behind step 1 ("give it a minute"); after that they come up to full contrast. The numbering is the order to actually try them in — the only reason it is numbered.
- **Builds its own commands** from the address you are connected to, and gives each a copy button, because you have to paste them into a terminal that is not this one. A tunnel URL is deliberately never used: that is exactly what stops resolving when the daemon dies.
- **Not a modal.** The terminals behind it still hold the work you were reading. Dismissible, and the red status word brings it back.

**In the repo** — `RECOVERY.md`, the longer version, readable when there is no dashboard to open: what each symptom means, the four commands, how to read `/api/fleet/restore`'s answer, the `closedByUser` tombstone that legitimately blocks recovery, restoring from a specific backup by hand, and a short list of what is and is not safe to do while panicking. Linked from the README.

Verified in a live dashboard at both stages.