### PR TITLE
fix(agent-tasks): stop the launch-marker regex backtracking the daemon to a halt

### DIFF
--- a/server/src/agentTasks.js
+++ b/server/src/agentTasks.js
@@ -42,7 +42,16 @@ function encodeCwd(cwd) {
 // task-notification's id tag. Both verified against live transcripts
 // (2026-08-27); ids are the basename so the same regex covers agents
 // (agent-…jsonl symlinks), background shells, and future task kinds.
-const LAUNCH_RE = /([^\s"'\\]*\/tasks\/([A-Za-z0-9_-]{4,})\.output)/g;
+//
+// The launch marker anchors on the literal `/tasks/<id>.output` and recovers
+// the path prefix by walking backwards (see _pathStart). It must NOT lead
+// with `[^\s"'\\]*`: that prefix backtracks quadratically at every start
+// offset of an unbroken token, and transcripts routinely carry ~600 KB runs
+// with no whitespace or quote in them (a pasted base64 image is one). On a
+// 4 MB backfill that is hours of synchronous regex inside the 4s sampler —
+// it wedges the event loop and the daemon stops answering /api/ping.
+const LAUNCH_RE = /\/tasks\/([A-Za-z0-9_-]{4,})\.output/g;
+const PATH_BREAK = /[\s"'\\]/;
 const DONE_RE = /<task-id>\s*([A-Za-z0-9_-]{4,})\s*<\/task-id>/g;
 
 const _dirCache = new Map();   // cwd → { at, file }
@@ -77,10 +86,21 @@ function _stateFor(file) {
     return st;
 }
 
+// Start of the path token containing `/tasks/` — the span the old leading
+// `[^\s"'\\]*` used to consume, found by a linear scan instead.
+function _pathStart(chunk, at) {
+    let i = at;
+    while (i > 0 && !PATH_BREAK.test(chunk[i - 1])) i--;
+    return i;
+}
+
 function _parseChunk(st, chunk) {
     let m;
     LAUNCH_RE.lastIndex = 0;
-    while ((m = LAUNCH_RE.exec(chunk))) st.launched.set(m[2], m[1]);
+    while ((m = LAUNCH_RE.exec(chunk))) {
+        const start = _pathStart(chunk, m.index);
+        st.launched.set(m[1], chunk.slice(start, m.index + m[0].length));
+    }
     DONE_RE.lastIndex = 0;
     while ((m = DONE_RE.exec(chunk))) st.notified.add(m[1]);
 }

--- a/server/test/agentTasks.test.js
+++ b/server/test/agentTasks.test.js
@@ -93,3 +93,21 @@ test('a truncated/rotated transcript resets cleanly instead of mixing state', ()
     fs.writeFileSync(J(), noticeLine('other0')); // smaller file, unrelated content
     assert.equal(agentTasks.runningFor(CWD).running, 0);
 });
+
+// A single transcript line can carry a very long token with no whitespace,
+// quote or backslash in it — a pasted base64 image is the everyday case, and
+// ~600 KB runs show up in real transcripts. The launch marker must not scan
+// such a run by backtracking: the earlier `[^\s"'\\]*\/tasks\/…` form was
+// quadratic in the run length, which on a 4 MB backfill is hours of blocking
+// regex inside the 4s sampler — it wedged the event loop and the daemon
+// stopped answering /api/ping.
+test('a long unbroken token does not blow up the launch scan (no quadratic backtracking)', () => {
+    reset();
+    const noise = 'A'.repeat(200000); // one run: no \s, " , ' or \ to break it
+    const st = agentTasks._stateFor('backtracking-probe');
+    const started = process.hrtime.bigint();
+    agentTasks._parseChunk(st, `${noise} ${outPath('base64')} trailing text`);
+    const ms = Number(process.hrtime.bigint() - started) / 1e6;
+    assert.ok(ms < 2000, `launch scan took ${ms.toFixed(0)}ms over a 200k-char token — the regex is backtracking`);
+    assert.equal(st.launched.get('base64'), outPath('base64'), 'the marker after the run is still parsed');
+});


### PR DESCRIPTION
## What broke

`install.sh` refused to run, every time:

```
xx  port 4010 is in use by node (pid 829) and it does not answer /api/ping as SoA-Web.
```

The port owner *was* SoA-Web. It just never answered — pegged at 99% CPU with a wedged event loop. `sample(1)` put 100% of stacks in `Builtins_RegExpPrototypeExec`, under `uv__run_timers` → `Environment::RunTimers`.

## Why

`agentTasks.js` matched launches with:

```js
const LAUNCH_RE = /([^\s"'\\]*\/tasks\/([A-Za-z0-9_-]{4,})\.output)/g;
```

The leading `[^\s"'\\]*` is greedy and matches `/` as well. On a token with no `/tasks/` in it, the engine consumes the entire run, backtracks one character at a time, fails, then advances the start offset by one and does it again — **O(n²) in the length of the run**.

Transcripts are full of long unbroken tokens, because a pasted base64 image contains no whitespace, quote or backslash. Scanning the 4 MB backfill window across local transcripts, the longest single run is **589,660 characters**.

Timed on a live 9 MB transcript — textbook quadratic:

| slice of the 4 MB tail | time |
| --- | --- |
| 20 KB | 0.7 s |
| 41 KB | 2.9 s |
| 82 KB | 11.4 s |
| 164 KB | 46.1 s |

Extrapolated, the full tail is **~8 hours of blocking regex for one tab**.

`runningFor()` runs on the 4-second `agentSample` timer, so the first sweep after boot never returned. The result was a permanent loop: boot → rehydrate tabs → wedge → watchdog kills it → `KeepAlive` respawns → backfill restarts from zero. Local logs showed **45 boots** and 40 unbroken minutes of `daemon not answering /api/tabs on :4010`.

The installer error was only the symptom — `ping_ok` timed out, so the `lsof` guard named the owner and bailed.

## The fix

Anchor on the literal `/tasks/<id>.output`, then recover the path prefix with a linear backward scan:

```js
const LAUNCH_RE = /\/tasks\/([A-Za-z0-9_-]{4,})\.output/g;
const PATH_BREAK = /[\s"'\\]/;
```

`{4,}` stays bounded by the `/tasks/` literal, so it can no longer be entered at arbitrary offsets.

## Verification

- **Equivalence** — old vs new checked across absolute, relative, repeated, embedded-in-JSON, long-prefix and no-match inputs: identical ids and identical full paths in every case.
- **Existing tests** — all 7 `agentTasks` tests pass unmodified; full suite **171/171**.
- **Regression test** added: **64,389 ms** against the old pattern, **1.05 ms** against this one.
- **Cold sweep** across all 8 restored tabs: ~8 h/tab → **26.6 ms total**.
- **In situ** — daemon restarted with the patch: single PID held for 90 s, ~0% CPU, `/api/ping` at ~14 ms, and `install.sh` now exits 0 with `a healthy SoA-Web backend already answers on 127.0.0.1:4010 — adopting it.`

## Note

Introduced by #4 and live on `main` as of cb30ad0, so a fresh `install.sh` clone hits it too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012YxySTPSKPsc1QhRMsFH7a
