### PR TITLE
perf(term): give the viewport its native scroll back, and budget the poll

### DIFF
--- a/web/public/assets/app.js
+++ b/web/public/assets/app.js
@@ -877,6 +877,14 @@ class Shell {
         this._applyTheme();
         onSystemThemeChange(() => { if (getSettings().theme === 'auto') this._applyTheme(); });
 
+        // Interaction stamp — the context poll reads it to stay off the main
+        // thread while you are scrolling (see _pollCtxLines). Passive and
+        // capture so it is recorded no matter who handles the event.
+        const bump = () => { this._lastInteract = performance.now(); };
+        window.addEventListener('wheel', bump, { passive: true, capture: true });
+        window.addEventListener('keydown', bump, { capture: true });
+        window.addEventListener('touchmove', bump, { passive: true, capture: true });
+
         window.addEventListener('resize', () => this._fitActive());
         window.addEventListener('orientationchange', () => setTimeout(() => this._fitActive(), 150));
         window.addEventListener('keydown', e => this._hotkey(e));
@@ -1745,17 +1753,52 @@ class Shell {
         }, 0);
     }
 
+    // How many tabs one tick may scan. Each tab costs ~66 row → string
+    // translations plus the regexes over them (the whole visible screen for the
+    // context reading, the last 20 rows for agent status), and on a fleet where
+    // every agent is producing output EVERY tab is dirty on EVERY tick. Nineteen
+    // of them twice a second is thousands of allocations per second competing
+    // with scrolling, which is what made scrolling feel delayed rather than
+    // slow. A budget turns that into a round-robin: the tab you are looking at
+    // is always current, the rest refresh within a few seconds.
+    static POLL_BUDGET = 4;
+
     _pollCtxLines() {
         // Don't burn the main thread scanning 16 terminals while the page is in
         // a background tab — resume with a full sweep once it's foregrounded.
         if (document.hidden) { this._pollWasHidden = true; return; }
+        // Never scan while the user is working the terminal. Scrolling is the
+        // one interaction that has to stay at frame rate, and a poll that lands
+        // mid-gesture is felt directly. It resumes a moment after the last
+        // wheel or keystroke; nothing is lost, the tabs stay dirty.
+        if (performance.now() - (this._lastInteract || 0) < 250) return;
         // Fast path: only re-scan tabs that emitted output since the last tick.
         // Full sweep every ~8s (and on return from hidden) guarantees eventual
         // consistency even if a dirty-seed site is ever missed.
         const full = this._pollWasHidden || (++this._pollTickN % 16 === 0);
         this._pollWasHidden = false;
-        for (const [id, rt] of this.tabs) {
-            if (!full && !this._pollDirty.has(id)) continue;
+
+        // Pick this tick's slice: the visible tab first — it must never be
+        // starved by the rotation — then as many others as the budget allows,
+        // resuming where the last tick stopped so every tab comes round.
+        const ids = [...this.tabs.keys()];
+        const due = ids.filter(id => full || this._pollDirty.has(id));
+        let slice;
+        if (due.length <= Shell.POLL_BUDGET) {
+            slice = due;
+        } else {
+            const start = (this._pollCursor || 0) % due.length;
+            slice = [];
+            for (let i = 0; i < Shell.POLL_BUDGET; i++) slice.push(due[(start + i) % due.length]);
+            this._pollCursor = start + Shell.POLL_BUDGET;
+            if (this.activeId != null && due.includes(this.activeId) && !slice.includes(this.activeId)) {
+                slice[slice.length - 1] = this.activeId;
+            }
+        }
+
+        for (const id of slice) {
+            const rt = this.tabs.get(id);
+            if (!rt) continue;
             this._pollDirty.delete(id);
             if (rt._opened) {
                 try {

--- a/web/public/assets/styles.css
+++ b/web/public/assets/styles.css
@@ -777,15 +777,22 @@ html, body {
 .terms .xterm { height: 100%; width: 100%; }
 .terms .xterm-viewport {
   background: transparent !important;
-  /* FitAddon sizes the terminal by subtracting the viewport's scrollbar
-     width (offsetWidth − clientWidth) from the parent. If the viewport
-     still scrolls, Chromium on a trackpad-less machine reserves ~15px and
-     the grid stops one column short, leaving a dark gutter on the right.
-     Dropping overflow to hidden collapses that reservation to 0 — xterm
-     still receives wheel events from this element, so scrollback keeps
-     working. */
-  overflow: hidden !important;
+  /* This used to be `overflow: hidden`, to stop FitAddon subtracting a phantom
+     ~15px scrollbar and leaving a dark gutter on the right. It worked, and it
+     cost the scrolling: an element that cannot scroll natively gets no
+     compositor scrolling and no trackpad momentum, so every wheel event became
+     a whole-line jump on the main thread — steppy and a beat late.
+
+     The gutter is handled properly now. _fillWidth measures the CONTAINER and
+     grows the grid to fill it whatever the viewport reserves, and hiding the
+     scrollbar in both engines below means it reserves nothing anyway. So give
+     the viewport its native scroll back. */
+  overflow-y: auto;
+  overflow-x: hidden;
   scrollbar-width: none;
+  /* A terminal at the end of its scrollback should not start scrolling the
+     page behind it. */
+  overscroll-behavior: contain;
 }
 .terms .xterm-viewport::-webkit-scrollbar { width: 0; height: 0; }
 .terms .xterm-screen { width: 100% !important; }


### PR DESCRIPTION
Scrolling was still sluggish and delayed after the renderer change. Two remaining causes, both measured on the live dashboard.

**1. The viewport could not scroll.** `.terms .xterm-viewport` was pinned to `overflow: hidden !important` to stop FitAddon subtracting a phantom ~15px scrollbar and leaving a dark gutter. The side effect: an element that cannot scroll natively gets no compositor scrolling and no trackpad momentum, so xterm fell back to turning each wheel event into a whole-line jump on the main thread — steppy, and a beat behind the gesture.

That workaround is obsolete. `_fillWidth` measures the container and grows the grid to fill it whatever the viewport reserves, and with the scrollbar hidden in both engines it reserves nothing. Verified after the change: `overflowY: scroll`, `offsetWidth − clientWidth: 0`, gap unchanged at the container's 6px padding, and a real `scrollHeight` of 1007 against a 692 client height.

**2. The context poll was scanning everything, twice a second.** Per dirty tab it translates the whole visible screen to strings for the context reading, plus the last 20 rows for agent status — ~66 row translations and the regexes over them. The dirty-set optimisation does nothing on this fleet, because when every agent is producing output every tab is dirty on every tick: nineteen tabs at 2Hz is thousands of allocations per second competing with the scroll.

Now capped at four tabs per tick, round-robin so every tab still comes round within a few seconds, with the visible tab never starved. And the tick is skipped entirely within 250ms of a wheel, keydown or touchmove — scrolling is the one interaction that has to hold frame rate, and nothing is lost because the tabs stay dirty.