### PR TITLE
fix(audio): start muted on every load, not just the first

### DIFF
--- a/web/public/assets/settings.js
+++ b/web/public/assets/settings.js
@@ -98,7 +98,18 @@ function load() {
     } catch (_) { return normalize(null); }
 }
 
+// Sound FX start muted on EVERY load, not just the first one. Audio is the one
+// setting whose "on" is nearly always meant for the moment rather than for
+// good — you turn it on to hear something and then a reload, a reconnect, or a
+// second device brings it back unasked, usually somewhere you did not want a
+// terminal chirping. So the stored value is cleared at startup: turning it on
+// lasts for the session, and the next load is quiet again. Volume and the
+// individual cue toggles persist normally; only the master switch resets.
 let current = load();
+if (current.audio) {
+    current = normalize({ ...current, audio: false });
+    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(current)); } catch (_) {}
+}
 
 export function getSettings() { return { ...current }; }
 


### PR DESCRIPTION
`DEFAULTS.audio` was already `false`, so a fresh install is silent — but the setting persists, so once you turn sound on it stays on through every reload, reconnect and second device that opens the dashboard. That is nearly always the wrong default for audio specifically: you turn it on to hear something now, not to be chirped at from a laptop in another room tomorrow.

The stored master switch is now cleared at startup. Turning sound on lasts for the session; the next load is quiet again. `audioVolume` and the individual cue toggles (`disableFeedbackAudio`, `agentDoneSound`) persist normally — only the master switch resets.

Verified in a live dashboard: set `audio: true`, reload, stored value comes back `false`.