### PR TITLE
fix(term): give SoA shells a UTF-8 locale

### DIFF
--- a/server/src/envStore.js
+++ b/server/src/envStore.js
@@ -64,9 +64,18 @@ function activeProvider(config) {
     return c.active ? c.providers.find(p => p.id === c.active) || null : null;
 }
 
+// launchd starts the daemon with no locale, and a PTY inherits it — so every
+// SoA shell ran with LANG unset and LC_CTYPE=C. Bytes still reach xterm intact,
+// which is why the screen always looked right, but anything that decodes and
+// re-encodes text inside that shell treats UTF-8 as single bytes: a pasted box
+// drawing character comes back out as `‚îÄ`, an em dash as `‚Äî`. That is the
+// "terminal copying" corruption — not the clipboard, the locale. A user's own
+// LANG (or one set in Settings' custom env) still wins; this is only the floor.
+const LOCALE_DEFAULTS = { LANG: 'en_US.UTF-8', LC_ALL: 'en_US.UTF-8' };
+
 function getEnvForShell() {
     const config = load();
-    const env = {};
+    const env = { ...LOCALE_DEFAULTS };
     // Legacy single-endpoint settings first, then the active provider profile
     // overrides — switching providers in Settings wins over old env.json fields.
     if (config.claude.baseUrl) env.ANTHROPIC_BASE_URL = config.claude.baseUrl;


### PR DESCRIPTION
The recurring "terminal copying" corruption — `‚îÄ‚îÄ‚îÄ` where a box-drawing table should be, `‚Äî` for an em dash — is not the clipboard. Every SoA shell runs with **`LANG` unset and `LC_CTYPE=C`**, inherited from launchd, which starts the daemon with no locale.

Bytes still reach xterm intact, so the screen always looked correct. But any program in that shell that decodes and re-encodes text treats UTF-8 as single bytes. Exactly reproducible:

```python
'─┬│—×·'.encode('utf-8').decode('mac_roman')   # -> '‚îÄ‚î¨‚îÇ‚Äî√ó¬∑'
```

Byte-for-byte the garbage that came back from a copied table, `√ó` for `×` and `¬∑` for `·` included.

`getEnvForShell()` now seeds `LANG`/`LC_ALL` as `en_US.UTF-8` (verified present via `locale -a`), and every shell-spawn path goes through it — new tabs, restored tabs, fleet restore, session manager. A user's own `LANG`, or one set in Settings' custom env, still overrides it; this is only the floor.

Server-side, so it takes effect for shells spawned after the next daemon restart.