### PR TITLE
perf(ui): stop the globe competing with the terminal

### DIFF
--- a/web/public/assets/app.js
+++ b/web/public/assets/app.js
@@ -880,7 +880,10 @@ class Shell {
         // Interaction stamp — the context poll reads it to stay off the main
         // thread while you are scrolling (see _pollCtxLines). Passive and
         // capture so it is recorded no matter who handles the event.
-        const bump = () => { this._lastInteract = performance.now(); };
+        // Published on window as well: the sidebar's globe animation reads it to
+        // get out of the way while you are scrolling. A one-word global beats
+        // wiring an event bus through a decorative widget.
+        const bump = () => { this._lastInteract = window.__soaLastInteract = performance.now(); };
         window.addEventListener('wheel', bump, { passive: true, capture: true });
         window.addEventListener('keydown', bump, { capture: true });
         window.addEventListener('touchmove', bump, { passive: true, capture: true });

--- a/web/public/assets/widgets.js
+++ b/web/public/assets/widgets.js
@@ -1042,14 +1042,27 @@ class LocationGlobeWidget extends Widget {
         }
     }
 
+    // Decoration runs at decoration's frame rate. A slowly turning globe is
+    // indistinguishable at 24fps and at 60, and the terminal shares both the
+    // main thread and the GPU with it.
+    static ANIM_MS = 42;          // ~24fps
+    // And it stops entirely while the terminal is being scrolled or typed in.
+    // Nothing decorative is worth a dropped frame in the thing you are reading.
+    static YIELD_MS = 300;
+
     _tickAnim() {
         this._rafId = null;
         if (this._destroyed) return;
-        // The globe is pure decoration — don't spin a 60fps WebGL loop while the
-        // page is backgrounded or the canvas is scrolled out of view. _kickAnim
+        // The globe is pure decoration — don't spin a WebGL loop while the page
+        // is backgrounded or the canvas is scrolled out of view. _kickAnim
         // restarts it when it becomes visible again.
         if (document.hidden || this._offscreen) return;
-        try { this.globe.tick(); } catch (_) {}
+        const now = performance.now();
+        const busy = now - (window.__soaLastInteract || 0) < LocationGlobeWidget.YIELD_MS;
+        if (!busy && now - (this._lastFrame || 0) >= LocationGlobeWidget.ANIM_MS) {
+            this._lastFrame = now;
+            try { this.globe.tick(); } catch (_) {}
+        }
         this._rafId = requestAnimationFrame(() => this._tickAnim());
     }
 


### PR DESCRIPTION
Scrolling improved after #18/#19 but was still not smooth. The sidebar's WORLD VIEW globe is a three.js WebGL animation on a full-rate `requestAnimationFrame` loop, running whenever the sidebar is visible — and since #18 it shares the GPU with the terminal's renderer as well as the main thread. Its own comment calls it "pure decoration".

- Capped to ~24fps. A slowly turning globe is indistinguishable from 60fps.
- Stopped entirely for 300ms after any wheel, keydown or touchmove, reading the same interaction stamp the context poll uses (now published on `window` so a decorative widget can see it without an event bus).

It already paused when the page was hidden or the canvas scrolled out of view; this covers the case that actually matters, which is the sidebar being visible while you scroll the terminal.