### PR TITLE
feat(term): band the conversation only, and from behind the text

### DIFF
--- a/web/public/assets/app.js
+++ b/web/public/assets/app.js
@@ -188,7 +188,12 @@ class TabRuntime {
         this.term = new Terminal({
             fontFamily: 'Fira Mono, ui-monospace, Menlo, Consolas, monospace',
             fontSize,
-            theme: xtermTheme(resolveTheme(s.theme)),
+            // The terminal paints no ground of its own: .terms supplies it, in
+            // the same token, and the gap is where the conversation bands live.
+            // Washing text from ABOVE was the first attempt and it dulled every
+            // glyph it covered; from behind, the tint costs the text nothing.
+            allowTransparency: true,
+            theme: { ...xtermTheme(resolveTheme(s.theme)), background: 'rgba(0,0,0,0)' },
             cursorBlink: s.cursorBlink,
             // Minimal per-tab browser memory: each xterm buffer is the dominant
             // client-side cost, and with ~20 tabs a 5000-line buffer per tab was
@@ -334,8 +339,13 @@ class TabRuntime {
             // Claude Code marks your turn with a prompt caret and its own work
             // with a bullet; the box-drawing continuations belong to whatever
             // opened them, which the run-grouping below handles.
+            // Only the conversation is banded. Tool calls, shell output and
+            // diffs are the machinery around it, and marking those too turned
+            // the transcript into stripes — the noise the banding was meant to
+            // cut through. A marker line ends the block before it, so a bullet
+            // still matters here: it is what CLOSES your turn.
             if (c === '>' || c === '\u276f' || c === '\u203a') kind = 'user';
-            else if (c === '\u25cf' || c === '\u23fa' || c === '\u2022') kind = 'tool';
+            else if (c === '\u25cf' || c === '\u23fa' || c === '\u2022') kind = 'end';
         }
         // Only history is safe to remember; the live screen is still being
         // repainted underneath us.
@@ -370,7 +380,9 @@ class TabRuntime {
         let cur = null;
         for (let i = 0; i < rows; i++) {
             const kind = this._bandFor(buf, top + i);
-            if (kind) {
+            if (kind === 'end') {
+                if (cur) { runs.push(cur); cur = null; }
+            } else if (kind) {
                 if (cur) runs.push(cur);
                 cur = { kind, from: i, to: i };
             } else if (cur) {

--- a/web/public/assets/styles.css
+++ b/web/public/assets/styles.css
@@ -3189,39 +3189,38 @@ html[data-welcome="1"] body { overflow: hidden; overflow-y: auto; }
 }
 .mgrv-toast.show { opacity: 1; transform: translateX(-50%) translateY(0); }
 
-/* ── Transcript bands ───────────────────────────────────────────────────
+/* ── Conversation bands ─────────────────────────────────────────────────
    A Claude run is thousands of lines in which your question, the reply and
-   every tool call are the same monospace grey. These bands give the terminal
-   the block structure the desktop app has, without touching the text: a
-   saturated left rail does the tracking work and the fill is barely there, so
-   nothing competes with the glyphs it sits on top of.
+   every tool call are the same monospace grey. Only the CONVERSATION is
+   marked: banding the tool calls as well turned the transcript into stripes,
+   which is the noise this was meant to cut through, not add to.
 
-   The layer is above the canvas because the dark theme paints an opaque
-   background into it — anything underneath would simply not be seen. Hence the
-   very low alphas: this is a wash, not a highlight. */
+   The layer sits BEHIND the grid. xterm now paints no background of its own
+   (allowTransparency, and .terms supplies the ground), so the tint reaches the
+   glyphs from underneath and costs their contrast nothing — the first version
+   washed over the top and dulled every character it covered. */
 .term-bands {
   position: absolute; inset: 4px 0 4px 6px;   /* match .terms .term padding */
-  pointer-events: none; overflow: hidden; z-index: 2;
+  pointer-events: none; overflow: hidden; z-index: 0;
 }
+.terms .term .xterm { position: relative; z-index: 1; }
+
 .term-band {
   position: absolute; left: 0; right: 0; top: 0;
-  border-left: 2px solid transparent;
   will-change: transform;
 }
-/* Spend the emphasis in ONE place. Your own turn is the thing you scroll back
-   to find, so it gets the wash and a full-strength rail. */
+/* Your turn: the one thing you scroll back to find, so it is the one place any
+   emphasis is spent. A rail marks where it starts, the tint carries it down. */
 .term-band[data-kind="user"] {
-  background: rgba(var(--soa-accent-rgb), 0.10);
-  border-left-width: 3px;
-  border-left-color: var(--soa-accent);
+  background: linear-gradient(90deg,
+      rgba(var(--soa-accent-rgb), 0.13) 0%,
+      rgba(var(--soa-accent-rgb), 0.05) 42%,
+      rgba(var(--soa-accent-rgb), 0) 100%);
+  box-shadow: inset 2px 0 0 var(--soa-accent);
 }
-/* Its work only needs a margin mark. A second wash would turn the transcript
-   into stripes and cost the contrast the first one is buying. */
-.term-band[data-kind="tool"] {
-  border-left-color: var(--soa-accent-dim);
-  opacity: 0.75;
-}
-/* On the light themes the wash has to come from the ink, not the accent glow,
-   or it vanishes against a near-white ground. */
+/* On a near-white ground the accent glow disappears; the ink has to carry it. */
 :root[data-theme="light"] .term-band[data-kind="user"],
-:root[data-theme="dim"] .term-band[data-kind="user"] { background: rgba(0, 0, 0, 0.06); }
+:root[data-theme="dim"] .term-band[data-kind="user"] {
+  background: linear-gradient(90deg,
+      rgba(0, 0, 0, 0.075) 0%, rgba(0, 0, 0, 0.03) 42%, rgba(0, 0, 0, 0) 100%);
+}


### PR DESCRIPTION
Redo of #23, which did not read well.

**It banded the tool calls too.** That turned a transcript into stripes — exactly the noise the banding was supposed to cut through. Only the conversation is marked now. A tool bullet still matters to the classifier, but as the thing that *closes* your turn rather than as a block of its own.

**It washed the tint over the top of the glyphs.** The dark theme paints an opaque background into the canvas, so a band underneath would not be seen at all — the first version had to sit above, and every character it covered lost contrast for it. The terminal now paints no ground of its own (`allowTransparency`, with `.terms` supplying the same background token), so the band sits **behind** the text and costs it nothing. That is what makes a real tint affordable instead of a barely-there wash.

The band is a left rail where your turn starts plus a gradient that fades out to the right, so the mark is strongest where the eye begins a line and gone by the time it reaches the end.

Verified against a live transcript: bands appear on user turns only, correctly grouped and positioned, terminal background transparent with `.terms` providing the ground.