### PR TITLE
fix(term): never band the composer

### DIFF
--- a/web/public/assets/app.js
+++ b/web/public/assets/app.js
@@ -390,6 +390,15 @@ class TabRuntime {
             }
         }
         if (cur) runs.push(cur);
+        // Never band the composer. It opens with the same caret as a submitted
+        // turn, so nothing in the first eight columns tells them apart — but a
+        // turn you have SENT is always closed by a bullet, and the line you are
+        // still typing is not: it runs to the bottom of the live screen, taking
+        // the footer hints with it. Drop that block, and only while the
+        // viewport is actually at the bottom; scrolled back, a real turn is
+        // free to continue past the last visible row.
+        const atBottom = buf.viewportY >= buf.baseY;
+        if (atBottom && runs.length && runs[runs.length - 1].to === rows - 1) runs.pop();
 
         // Reuse the divs: a scroll re-lays the same handful of bands, and
         // rebuilding the subtree every frame would undo the point of this.


### PR DESCRIPTION
The conversation band was also tinting the text input area.

The composer opens with the same caret as a submitted turn, so nothing in the eight columns the classifier reads distinguishes them. What does distinguish them is how they end: **a turn you have sent is always closed by a bullet, and the line you are still typing is not** — it runs to the bottom of the live screen, taking the footer hints with it. So a run that reaches the last visible row while the viewport is at the bottom is the composer, and is dropped.

The `atBottom` guard matters: scrolled back into history, a real turn is free to continue past the last visible row and must keep its band.

Verified live. At the bottom of the buffer the remaining band spans 480→645px of a 692px overlay — a real turn, stopping short of the composer — and a sweep across the scrollback still finds bands at every position that has a user turn in view.