### PR TITLE
fix(term): only band a caret in column 0

### DIFF
--- a/web/public/assets/app.js
+++ b/web/public/assets/app.js
@@ -334,8 +334,14 @@ class TabRuntime {
         let kind = '';
         const line = buf.getLine(abs);
         if (line) {
-            const head = line.translateToString(true, 0, TabRuntime.BAND_COLS).trimStart();
-            const c = head.charAt(0);
+            // Column matters. A turn you SENT has its caret in column 0; the
+            // carets Claude Code draws inside its own boxes — the queued-message
+            // list it shows while working, the composer — are indented into
+            // those boxes, and it already gives them a grey block of their own.
+            // Banding them again was redundant on top of redundant. Allow one
+            // leading space and no more.
+            const head = line.translateToString(true, 0, TabRuntime.BAND_COLS);
+            const c = head.charAt(0) === ' ' ? head.charAt(1) : head.charAt(0);
             // Claude Code marks your turn with a prompt caret and its own work
             // with a bullet; the box-drawing continuations belong to whatever
             // opened them, which the run-grouping below handles.


### PR DESCRIPTION
While the agent is working, Claude Code lists queued messages in a box and already renders them with a grey block. The conversation band was drawing a second highlight over that — redundant on top of redundant.

Column is the discriminator: a turn you **sent** has its caret in column 0, while every caret Claude Code draws inside its own chrome (the queued-message list, the composer) is indented into that box. The classifier no longer trims leading whitespace before looking — one leading space is allowed, nothing more.

Verified live: a sweep across the scrollback still finds bands at six separate positions, so real turns are untouched, and the bottom of the buffer — queued box and composer — now has none.