### PR TITLE
fix(term): derive the cell width from the painted canvas

### DIFF
--- a/web/public/assets/app.js
+++ b/web/public/assets/app.js
@@ -548,14 +548,29 @@ class TabRuntime {
                 if (r && r.width > 0 && this.term.cols > 0) cellW = r.width / this.term.cols;
             }
             // .xterm-rows only exists under the DOM renderer — canvas and WebGL
-            // paint into a <canvas> and drop the rows layer entirely. Measure the
-            // font directly as the last resort so this works under every renderer.
+            // paint into a <canvas> and drop the rows layer entirely, which is
+            // how the right-hand strip came back the moment a GPU renderer was
+            // switched on. The painted canvas is exactly cols x cellW, so divide
+            // it: renderer-derived, no font guessing, no rounding drift.
+            if (!(cellW > 0.5) && this.term.element && this.term.cols > 0) {
+                let widest = 0;
+                for (const c of this.term.element.querySelectorAll('.xterm-screen canvas')) {
+                    const w = c.getBoundingClientRect().width;
+                    if (w > widest) widest = w;
+                }
+                if (widest > 0) cellW = widest / this.term.cols;
+            }
+            // Last resort: measure the font itself. Uses the Terminal's own
+            // options rather than computed style, which can report the stylesheet
+            // default instead of the face xterm is actually rendering with.
             if (!(cellW > 0.5) && this.term.element) {
+                const o = this.term.options || {};
                 const cs2 = getComputedStyle(this.term.element);
                 const ctx = TabRuntime._measureCtx
                     || (TabRuntime._measureCtx = document.createElement('canvas').getContext('2d'));
                 if (ctx) {
-                    ctx.font = `${cs2.fontSize} ${cs2.fontFamily}`;
+                    const fs = o.fontSize ? `${o.fontSize}px` : cs2.fontSize;
+                    ctx.font = `${fs} ${o.fontFamily || cs2.fontFamily}`;
                     const w = ctx.measureText('W'.repeat(100)).width / 100;
                     if (w > 0.5) cellW = w;
                 }


### PR DESCRIPTION
The empty strip on the right came back when the GPU renderer landed — and #18's own description flagged the reason without me following it through: `_fillWidth`'s fallback measured `.xterm-rows`, which **canvas and WebGL delete**.

That left only the font-measuring last resort, which builds its font string from `getComputedStyle` on `.xterm` — not necessarily the face xterm is actually rendering with. Guess the cell even slightly wide and `floor(availW / cellW)` stops the grid several columns short of the container.

The painted canvas is exactly `cols × cellW`, so divide it. Renderer-derived, exact, and it works for both the canvas and WebGL renderers. Order is now: xterm's own dimensions → `.xterm-rows` (DOM renderer) → **painted canvas** → font measurement, and that last one now reads `term.options` instead of computed style.

Measured after the change: `availW 762, grid 756, gap 6` — six pixels is sub-cell remainder at a 7.2px cell, and it is the same colour as the terminal ground, so nothing shows.