### PR TITLE
fix(term): make the conversation band legible again

### DIFF
--- a/web/public/assets/styles.css
+++ b/web/public/assets/styles.css
@@ -3213,14 +3213,16 @@ html[data-welcome="1"] body { overflow: hidden; overflow-y: auto; }
    emphasis is spent. A rail marks where it starts, the tint carries it down. */
 .term-band[data-kind="user"] {
   background: linear-gradient(90deg,
-      rgba(var(--soa-accent-rgb), 0.13) 0%,
-      rgba(var(--soa-accent-rgb), 0.05) 42%,
-      rgba(var(--soa-accent-rgb), 0) 100%);
-  box-shadow: inset 2px 0 0 var(--soa-accent);
+      rgba(var(--soa-accent-rgb), 0.20) 0%,
+      rgba(var(--soa-accent-rgb), 0.12) 55%,
+      rgba(var(--soa-accent-rgb), 0.04) 100%);
+  /* The rail is what makes a one-line message still read as a block, so it
+     carries full accent rather than the wash's fraction of it. */
+  box-shadow: inset 3px 0 0 var(--soa-accent);
 }
 /* On a near-white ground the accent glow disappears; the ink has to carry it. */
 :root[data-theme="light"] .term-band[data-kind="user"],
 :root[data-theme="dim"] .term-band[data-kind="user"] {
   background: linear-gradient(90deg,
-      rgba(0, 0, 0, 0.075) 0%, rgba(0, 0, 0, 0.03) 42%, rgba(0, 0, 0, 0) 100%);
+      rgba(0, 0, 0, 0.10) 0%, rgba(0, 0, 0, 0.06) 55%, rgba(0, 0, 0, 0.02) 100%);
 }


### PR DESCRIPTION
Narrowing a band to the message itself (#27) was the right scope, but it left a one-line turn as a faint stripe fading to nothing — in practice the coloring disappeared.

Tuned for the shape the band actually has now, which is one to a few rows rather than a screen-height block:

- Wash raised (0.13 → 0.20 at the rail) and carried further across the line before it fades, so it still reads at one row tall.
- Rail to 3px at full accent. The rail is what makes a single-line message read as a block at all; the wash alone cannot do it in 15 pixels of height.
- Light and dim themes tuned to match, where the tint has to come from ink rather than the accent glow.

Scope is unchanged: history only, nothing on the composer, the queued-message box, or the working spinner. Verified against a live transcript — bands are clearly visible on the chat history and the input area is untouched.