### PR TITLE
feat(perf): a PERF widget that names what is slow

### DIFF
--- a/web/public/assets/app.js
+++ b/web/public/assets/app.js
@@ -21,6 +21,7 @@ import { AudioFX } from '/assets/audiofx.js?v=18';
 import { mountSidebar, setSidebarHidden } from '/assets/widgets.js?v=47';
 import { t as tr, getLang, setLang, applyStatic, LANGS } from '/assets/i18n.js?v=29';
 import { getSettings, onSettings, openSettingsModal, saveSettings, iso2ToFlagEmoji } from '/assets/settings.js?v=26';
+import { PERF, ptime, pstream } from '/assets/perf.js?v=1';
 import { pickFolder } from '/assets/folderPicker.js?v=1';
 import { mountContextPanel } from '/assets/contextPanel.js?v=5';
 import { resolveTheme, xtermTheme, applyThemeAttr, onSystemThemeChange } from '/assets/theme.js?v=3';
@@ -382,8 +383,9 @@ class TabRuntime {
     // until the next marker, and lay one absolutely-positioned band over each
     // run. Cheap enough to run per render and per scroll.
     paintBands() {
+        const _t0 = PERF.on ? performance.now() : 0;
         const host = this.bandsEl;
-        if (!host || !this._opened) return;
+        if (!host || !this._opened) { if (PERF.on) ptime('bands', _t0); return; }
         if (!this._bandsOn) { if (host.childElementCount) host.replaceChildren(); return; }
         let buf, cellH, rows;
         try {
@@ -442,6 +444,7 @@ class TabRuntime {
             const hp = `${h}px`;
             if (node.style.height !== hp) node.style.height = hp;
         }
+        if (PERF.on) ptime('bands', _t0);
     }
 
     // Is the painted grid leaving more than a cell of dead space in its own
@@ -1409,6 +1412,8 @@ class Shell {
     }
 
     _onTermData({ id, data }) {
+        const _s0 = PERF.on ? performance.now() : 0;
+        if (PERF.on) pstream(data ? data.length : 0);
         const t = this.tabs.get(id);
         if (t) {
             // Virtualization: only the on-screen terminal parses live into xterm;
@@ -1416,8 +1421,15 @@ class Shell {
             // on switch — so many sessions run ~1 live ANSI parser, not N. Status
             // and ctx% still update from the raw stream (below), so background tab
             // colours/preview stay live without parsing the full grid.
-            if (this._isLiveTab(id)) t.write(data);
-            else t.queueReplay(data);
+            if (this._isLiveTab(id)) {
+                const w0 = PERF.on ? performance.now() : 0;
+                t.write(data);
+                if (PERF.on) ptime('xterm write', w0);
+            } else {
+                const q0 = PERF.on ? performance.now() : 0;
+                t.queueReplay(data);
+                if (PERF.on) ptime('buffer bg', q0);
+            }
         }
         // Extract OSC 0/2 title sequences from the raw stream. xterm.js's
         // onTitleChange can miss titles when data arrives in chunks that split
@@ -1437,8 +1449,10 @@ class Shell {
             const partial = buf.match(/\x1b\](?:0|2);[^\x07\x1b]*$/);
             this._oscBuf.set(id, partial ? partial[0] : '');
         }
+        const _d0 = PERF.on ? performance.now() : 0;
         this._detectAgentFromStream(id, data);
         this._detectDevServer(id, data);
+        if (PERF.on) ptime('detectors', _d0);
         this._pollDirty.add(id);   // new output → re-scan status/context next tick
         // Throttle stdout cue per-tab so heavy output from one shell doesn't
         // gun-machine the speakers, but two tabs streaming in parallel can
@@ -1452,6 +1466,7 @@ class Shell {
             this._lastStdoutCue.set(id, now);
             this.audio.play('stdout', 'tab' + id);
         }
+        if (PERF.on) ptime('stream total', _s0);
     }
 
     _onTermExit({ id, code }) {
@@ -1981,6 +1996,11 @@ class Shell {
     static POLL_BUDGET = 4;
 
     _pollCtxLines() {
+        const _p0 = PERF.on ? performance.now() : 0;
+        try { this._pollCtxLinesInner(); } finally { if (PERF.on) ptime('ctx poll', _p0); }
+    }
+
+    _pollCtxLinesInner() {
         // Don't burn the main thread scanning 16 terminals while the page is in
         // a background tab — resume with a full sweep once it's foregrounded.
         if (document.hidden) { this._pollWasHidden = true; return; }

--- a/web/public/assets/i18n.js
+++ b/web/public/assets/i18n.js
@@ -156,6 +156,7 @@ const DICTS = {
         'widget.net.empty': 'no interfaces',
         'widget.git.empty': 'no commits',
         'widget.git.unavailable': 'unavailable',
+        'widget.perf': 'PERF',
         'widget.globe': 'WORLD VIEW',
         'widget.globe.online': 'online',
         'widget.globe.unavailable': 'globe unavailable',

--- a/web/public/assets/perf.js
+++ b/web/public/assets/perf.js
@@ -1,0 +1,143 @@
+/**
+ * perf — a live answer to "which part is making this slow?"
+ *
+ * Frame rate on its own cannot answer that question. Script monopolising the
+ * main thread and the GPU failing to paint look identical from the outside —
+ * both are just a low number — and they need opposite fixes. So this measures
+ * three things at once over a rolling one-second window:
+ *
+ *   fps          how many frames the page actually delivered
+ *   blocked      main-thread time past the 50ms long-task mark, per second
+ *   parts        where that time went, by subsystem
+ *
+ * BLOCKED is the discriminator. High blocked time means JavaScript is in the
+ * way, and `parts` names which subsystem to go after. Low blocked time with a
+ * low frame rate means paint or compositing, and no amount of script tuning
+ * will move it.
+ *
+ * Everything here is inert until perfStart(), and the call sites are all
+ * guarded by `PERF.on`, so a tool for measuring overhead does not become the
+ * overhead. The cost while running is one counter per frame, one addition per
+ * instrumented call, and a PerformanceObserver the browser feeds passively.
+ */
+
+// Read by the instrumented call sites, which is why it is a mutable object
+// rather than an exported boolean: `import { PERF }` then `PERF.on` sees the
+// current value, where a plain exported binding would be captured at import.
+export const PERF = { on: false };
+
+let frames = 0;
+let rafId = null;
+let blockedMs = 0;
+let observer = null;
+let bytes = 0;
+let chunks = 0;
+let windowStart = 0;
+const parts = new Map();   // subsystem name -> ms accumulated this window
+
+/** Record time spent in an instrumented block. `t0` comes from performance.now(). */
+export function ptime(name, t0) {
+    if (!PERF.on || !t0) return;
+    parts.set(name, (parts.get(name) || 0) + (performance.now() - t0));
+}
+
+/** Record one chunk of terminal output arriving from the daemon. */
+export function pstream(len) {
+    if (!PERF.on) return;
+    bytes += len || 0;
+    chunks++;
+}
+
+function reset(now) {
+    windowStart = now;
+    frames = 0;
+    blockedMs = 0;
+    bytes = 0;
+    chunks = 0;
+    parts.clear();
+}
+
+export function perfStart() {
+    if (PERF.on) return;
+    PERF.on = true;
+    reset(performance.now());
+
+    // Counting frames is the only honest way to know what the page delivered:
+    // a rAF that is never called is exactly the symptom being measured.
+    const loop = () => {
+        if (!PERF.on) return;
+        frames++;
+        rafId = requestAnimationFrame(loop);
+    };
+    rafId = requestAnimationFrame(loop);
+
+    // Long tasks are reported by the browser without polling. Everything past
+    // 50ms is time the page could not have painted in, which is the definition
+    // of blocking.
+    try {
+        observer = new PerformanceObserver(list => {
+            for (const e of list.getEntries()) blockedMs += Math.max(0, e.duration - 50);
+        });
+        observer.observe({ entryTypes: ['longtask'] });
+    } catch (_) {
+        observer = null;   // not supported here; fps and parts still work
+    }
+}
+
+export function perfStop() {
+    PERF.on = false;
+    if (rafId) { cancelAnimationFrame(rafId); rafId = null; }
+    if (observer) { try { observer.disconnect(); } catch (_) {} observer = null; }
+}
+
+/** Rates over the window since the last call, then start a fresh window. */
+export function perfSnapshot() {
+    const now = performance.now();
+    const secs = Math.max(0.05, (now - windowStart) / 1000);
+
+    let heapMb = 0;
+    try {
+        const m = performance.memory;
+        if (m && m.usedJSHeapSize) heapMb = m.usedJSHeapSize / 1048576;
+    } catch (_) {}
+
+    const snap = {
+        fps: frames / secs,
+        blockedMsPerSec: blockedMs / secs,
+        kbPerSec: bytes / 1024 / secs,
+        chunksPerSec: chunks / secs,
+        heapMb,
+        // A subsystem costing under a tenth of a millisecond a second is not
+        // the reason for anything, and listing it only buries the one that is.
+        parts: [...parts.entries()]
+            .map(([name, ms]) => ({ name, msPerSec: ms / secs }))
+            .filter(p => p.msPerSec >= 0.1)
+            .sort((a, b) => b.msPerSec - a.msPerSec),
+    };
+
+    // Learn the display's ceiling from the best second ever observed, so a
+    // 120Hz panel is judged against 120 rather than being told 60 is fine.
+    if (snap.fps > (window.__soaHz || 0)) window.__soaHz = snap.fps;
+
+    reset(now);
+    return snap;
+}
+
+/**
+ * One line naming the culprit. This is the whole point of the widget: not a
+ * number to interpret, but a statement about which half of the pipeline to fix.
+ */
+export function perfVerdict(s) {
+    const target = (window.__soaHz && window.__soaHz > 70) ? 120 : 60;
+    if (s.fps >= target * 0.85) return { level: 'ok', text: 'smooth' };
+    // Blocked time is the fork in the road.
+    if (s.blockedMsPerSec >= 30) {
+        const top = s.parts[0];
+        return {
+            level: s.blockedMsPerSec >= 80 ? 'bad' : 'warn',
+            text: top ? `main thread · ${top.name}` : 'main thread · js',
+        };
+    }
+    if (s.fps < target * 0.5) return { level: 'bad', text: 'paint / gpu' };
+    return { level: 'warn', text: 'paint / gpu' };
+}

--- a/web/public/assets/widgets.js
+++ b/web/public/assets/widgets.js
@@ -12,6 +12,7 @@
 
 import { t as tr } from '/assets/i18n.js?v=28';
 import { getSettings } from '/assets/settings.js?v=26';
+import { perfStart, perfStop, perfSnapshot, perfVerdict } from '/assets/perf.js?v=1';
 
 const $el = (tag, props = {}, children = []) => {
     const n = document.createElement(tag);
@@ -1695,6 +1696,66 @@ class ContributeWidget extends Widget {
 // ── Sidebar composition: registry + persisted layout ─────────────────────
 // Stable ids → constructors, in default order. Users hide/show and reorder
 // these via the CUSTOMIZE panel; the chosen layout persists in localStorage.
+
+// ── PERF ─────────────────────────────────────────────────────────────────
+// "Which part is making this slow?" — measured, not guessed.
+//
+// Frame rate alone cannot answer it: script blocking the main thread and the
+// GPU failing to paint look identical from outside, and they need opposite
+// fixes. BLOCKED is the discriminator — main-thread time past the 50ms mark
+// that the page could not have painted in. High blocked time means JavaScript,
+// and the breakdown below names which subsystem spent it; low blocked time
+// with low fps means paint, and no amount of script tuning will help.
+//
+// The probes are inert until this widget is on screen, so the tool cannot be
+// the thing it is measuring.
+const _ms = n => (n >= 100 ? Math.round(n) : n >= 10 ? n.toFixed(0) : n.toFixed(1)) + 'ms';
+
+class PerfWidget extends Widget {
+    constructor({ parent }) {
+        super({ titleKey: 'widget.perf', parent, intervalMs: 1000 });
+        this._fpsHist = [];
+        perfStart();
+    }
+
+    destroy() { perfStop(); super.destroy(); }
+    _suspend() { perfStop(); super._suspend(); }
+    _resume() { perfStart(); super._resume(); }
+
+    tick() {
+        const s = perfSnapshot();
+        const v = perfVerdict(s);
+        const fps = Math.round(s.fps);
+        this._fpsHist.push(fps);
+        if (this._fpsHist.length > 24) this._fpsHist.shift();
+
+        // Frame rate is the headline, and it is judged against the display, not
+        // against 60: a 120Hz panel that manages 60 is dropping every other
+        // frame and should not read as green.
+        const target = (window.__soaHz && window.__soaHz > 70) ? 120 : 60;
+        const fpsCls = fps >= target * 0.85 ? 'ok' : fps >= target * 0.5 ? 'warn' : 'err';
+
+        const rows = [
+            ['VERDICT', v.text, v.level === 'bad' ? 'err' : v.level === 'warn' ? 'warn' : 'ok'],
+            ['FPS', `${fps} / ${target}`, fpsCls],
+            ['BLOCKED', _ms(s.blockedMsPerSec) + '/s',
+                s.blockedMsPerSec >= 80 ? 'err' : s.blockedMsPerSec >= 30 ? 'warn' : 'ok'],
+            ['STREAM', `${s.kbPerSec.toFixed(0)} KB/s · ${Math.round(s.chunksPerSec)}/s`],
+        ];
+        if (s.heapMb) rows.push(['HEAP', Math.round(s.heapMb) + ' MB']);
+        if (!s.parts.length) {
+            rows.push(['—', 'no measurable js cost']);
+        } else {
+            // Only the spenders, biggest first. A subsystem costing under a
+            // tenth of a millisecond a second is not the reason for anything.
+            for (const p of s.parts.slice(0, 6)) {
+                rows.push([p.name, _ms(p.msPerSec) + '/s', p.msPerSec >= 50 ? 'warn' : null]);
+            }
+        }
+        this.setRows(rows);
+    }
+}
+
 function _widgetRegistry() {
     return [
         { id: 'clock',     titleKey: 'widget.clock',       make: p => new ClockWidget({ parent: p }) },
@@ -1714,6 +1775,7 @@ function _widgetRegistry() {
         { id: 'netchart',  titleKey: 'widget.net_chart',   make: p => new NetChartWidget({ parent: p }) },
         { id: 'commits',   titleKey: 'widget.commits',     make: p => new GitCommitsWidget({ parent: p }) },
         { id: 'contribute', titleKey: 'widget.contribute', make: p => new ContributeWidget({ parent: p }) },
+        { id: 'perf',      titleKey: 'widget.perf',        make: p => new PerfWidget({ parent: p }) },
     ];
 }
 


### PR DESCRIPTION
A live diagnosis in the left sidebar, so "which part is hindering performance" stops being a question we answer by pasting console snippets at each other.

Frame rate alone cannot answer it. Script monopolising the main thread and the GPU failing to paint look identical from outside — both are just a low number — and they need opposite fixes. So the widget measures three things over a rolling second:

- **VERDICT** — one line naming the half of the pipeline to fix.
- **FPS** — judged against the display's own ceiling, learned from the best second observed, so a 120Hz panel is not told that 60 is fine.
- **BLOCKED** — main-thread time past the 50ms long-task mark, per second. **This is the discriminator.** High means JavaScript is in the way; low with a low frame rate means paint or compositing.
- **STREAM** — KB/s and chunks/s arriving from the daemon, which is what ties frame rate to how loud the fleet is.
- **HEAP**, and a **per-subsystem breakdown** — `stream total`, `xterm write`, `buffer bg`, `detectors`, `ctx poll`, `bands` — biggest spender first, so when it does say "main thread" it also says which part.

Everything is inert until the widget is on screen and every call site is guarded by `PERF.on`, so the tool cannot become the overhead it measures.

**On provenance:** the instrumentation hooks in `app.js` and the widget class itself were already in this checkout, uncommitted, written by another agent working the same tree. They imported `/assets/perf.js`, which did not exist — the module graph could not resolve and the dashboard would have failed to load on the next reload. This adds the missing module and the `widget.perf` title, and commits the rest as found rather than discarding someone's work.

Verified in the agent browser, which runs `--disable-gpu`: `FPS 23/60, BLOCKED 0.0ms/s → paint / gpu`, with the breakdown showing every JS subsystem under 1ms/s. That is the correct diagnosis of that machine.