### PR TITLE
feat(clock): track other cities, with the day they are on

### DIFF
--- a/web/public/assets/i18n.js
+++ b/web/public/assets/i18n.js
@@ -80,6 +80,7 @@ const DICTS = {
         'settings.desc.audioVolume': 'Master volume (0.00 – 1.00).',
         'settings.desc.disableFeedbackAudio': 'Silence per-keystroke / per-output cues (stdin, stdout, keyboard).',
         'settings.desc.clockHours': 'Sidebar CLOCK format: 24 or 12.',
+        'settings.desc.clockZones': 'Cities the CLOCK widget tracks, as IANA zone names, comma separated (max 6).',
         'settings.desc.lang': 'Interface language.',
         'settings.conn.mode': 'MODE',
         'settings.conn.backend': 'BACKEND',

--- a/web/public/assets/settings.js
+++ b/web/public/assets/settings.js
@@ -34,6 +34,8 @@ export const DEFAULTS = Object.freeze({
     disableFeedbackAudio: false,
     agentDoneSound: true,
     clockHours: 24,
+    // Cities the CLOCK widget tracks alongside local time. IANA zone names.
+    clockZones: ['America/New_York', 'Europe/London', 'Asia/Tokyo', 'UTC'],
     // Which cells the unified view switcher shows. Terminal (tabs) is the
     // always-available escape hatch; the rest are user-customizable.
     viewButtons: { tabs: true, tiles: true, manager: true, chat: true, meeting: true, monitor: true },
@@ -49,6 +51,22 @@ function asViewButtons(v) {
     const out = {};
     for (const k of VIEW_KEYS) out[k] = src[k] !== false;   // default: shown
     out.tabs = true;                                        // terminal always on
+    return out;
+}
+
+// A zone is kept only if the platform can actually format with it, so a typo
+// degrades to "that city disappears" rather than throwing inside a 1s tick.
+const MAX_ZONES = 6;
+function asZones(v) {
+    const src = Array.isArray(v) ? v : DEFAULTS.clockZones;
+    const out = [];
+    for (const raw of src) {
+        const z = String(raw || '').trim();
+        if (!z || out.includes(z)) continue;
+        try { new Intl.DateTimeFormat('en-US', { timeZone: z }); } catch (_) { continue; }
+        out.push(z);
+        if (out.length >= MAX_ZONES) break;
+    }
     return out;
 }
 
@@ -87,6 +105,7 @@ function normalize(raw) {
         disableFeedbackAudio: asBool(s.disableFeedbackAudio, DEFAULTS.disableFeedbackAudio),
         agentDoneSound: asBool(s.agentDoneSound, DEFAULTS.agentDoneSound),
         clockHours: asHours(s.clockHours ?? DEFAULTS.clockHours),
+        clockZones: asZones(s.clockZones),
         viewButtons: asViewButtons(s.viewButtons),
     };
 }
@@ -343,6 +362,9 @@ function buildMiscPane(s) {
         ])]),
         el('tbody', {}, [
             kvRow('clockHours', 'settings.desc.clockHours', hoursSelect('set-clockHours', s.clockHours)),
+            kvRow('clockZones', 'settings.desc.clockZones',
+                el('input', { id: 'set-clockZones', type: 'text', value: s.clockZones.join(', '),
+                              placeholder: 'America/New_York, Europe/London' })),
             kvRow('lang',       'settings.desc.lang',       langSelect('set-lang')),
         ]),
     ]);
@@ -812,6 +834,7 @@ function collectFromDOM(prev) {
         disableFeedbackAudio: get('set-disableFeedbackAudio').value === 'true',
         agentDoneSound:       get('set-agentDoneSound') ? get('set-agentDoneSound').value === 'true' : (prev && prev.agentDoneSound),
         clockHours:           Number(get('set-clockHours').value),
+        clockZones:           get('set-clockZones').value.split(',').map(z => z.trim()).filter(Boolean),
         _lang:                get('set-lang').value,
     };
 }

--- a/web/public/assets/widgets.js
+++ b/web/public/assets/widgets.js
@@ -223,23 +223,56 @@ class Widget {
 }
 
 // ── CLOCK ────────────────────────────────────────────────────────────────
+// A zone's own label. The last path segment is the city, which is what anyone
+// reading a clock actually wants — 'America/New_York' is NEW YORK.
+function _zoneLabel(tz) {
+    if (!tz || tz === 'UTC') return 'UTC';
+    return tz.split('/').pop().replace(/_/g, ' ').toUpperCase();
+}
+
+// en-CA gives ISO order, which subtracts cleanly.
+function _ymdIn(now, tz) {
+    try { return now.toLocaleDateString('en-CA', { timeZone: tz }); } catch (_) { return null; }
+}
+
 class ClockWidget extends Widget {
     constructor({ parent }) {
         super({ titleKey: 'widget.clock', parent, intervalMs: 1000 });
     }
     tick() {
         const now = new Date();
-        const hours12 = getSettings().clockHours === 12;
+        const s = getSettings();
+        const hours12 = s.clockHours === 12;
         const time = hours12
             ? now.toLocaleTimeString('en-US', { hour12: true, hour: 'numeric', minute: '2-digit', second: '2-digit' })
             : now.toTimeString().slice(0, 8);
-        const date = now.toISOString().slice(0, 10);
-        const utc = now.toUTCString().slice(17, 25);
-        this.setRows([
+        const rows = [
             ['LOCAL', time],
-            ['DATE', date],
-            ['UTC', utc],
-        ]);
+            ['DATE', now.toISOString().slice(0, 10)],
+        ];
+
+        // The reason to put another city on a clock is to know whether you can
+        // call it, and the hour alone does not answer that — 07:04 is a
+        // different proposition depending on whose tomorrow it is. So each zone
+        // carries the day it is on there relative to here, and nothing when the
+        // two agree.
+        const hereYmd = _ymdIn(now, undefined) || now.toISOString().slice(0, 10);
+        for (const tz of (s.clockZones || [])) {
+            let t;
+            try {
+                t = now.toLocaleTimeString('en-US', {
+                    timeZone: tz, hour12: hours12, hour: '2-digit', minute: '2-digit',
+                });
+            } catch (_) { continue; }
+            const thereYmd = _ymdIn(now, tz);
+            let delta = 0;
+            if (thereYmd && hereYmd) {
+                delta = Math.round((Date.parse(thereYmd + 'T00:00:00Z') - Date.parse(hereYmd + 'T00:00:00Z')) / 86400000);
+            }
+            const day = delta > 0 ? `  +${delta}d` : delta < 0 ? `  ${delta}d` : '';
+            rows.push([_zoneLabel(tz), t + day]);
+        }
+        this.setRows(rows);
     }
 }
 


### PR DESCRIPTION
The CLOCK widget showed local time, the date, and UTC. It now tracks a configurable list of cities.

```
LOCAL      12:03:15
DATE       2026-09-09
NEW YORK      15:03
LONDON        20:03
TOKYO         04:03  +1d
UTC           19:03
```

**The `+1d` is the point.** The reason to put another city on a clock is to know whether you can call it, and the hour alone does not answer that — 04:03 is a different proposition depending on whose tomorrow it is. Each row carries the day it is on relative to here, and shows nothing when the two agree, so the marker only appears when it changes the answer.

Defaults are New York, London, Tokyo and UTC; the list is editable in Settings as comma-separated IANA zone names, capped at six. Each is validated against `Intl` when normalised, so a typo makes that city disappear rather than throwing inside a once-a-second tick. City labels come from the zone's last path segment, which is what a reader actually wants — `America/New_York` reads as `NEW YORK`.

Verified in a live dashboard, output above is the real widget.