### PR TITLE
ui(clock): one row, every time side by side, dial included

### DIFF
--- a/web/public/assets/sidebar.css
+++ b/web/public/assets/sidebar.css
@@ -759,73 +759,64 @@ body.ctx-resizing * { cursor: inherit !important; }
 }
 
 /* ── CLOCK ──────────────────────────────────────────────────────────────
-   Two faces and a secondary menu. The borrowed idea is Apple's: options laid
-   out in the open rather than hidden behind a dropdown, one clear primary
-   reading, and a world-clock list where the day offset — not the hour — is the
-   thing that answers your question. The execution stays this product's: mono
-   type, uppercase micro-labels, hairlines, phosphor rather than material. */
+   One row, and everything in it is the same kind of thing: local time and each
+   city are identical cells, so the clock is a glance rather than a list you
+   read down. The analog face is not a separate mode occupying the space above
+   — it is simply what a cell's value looks like when you pick it, which is why
+   five dials fit where one used to.
 
-.clock-face { display: flex; justify-content: center; padding: 2px 0 8px; }
+   Borrowed from Apple: every option visible at once, one primary reading, and
+   a world clock whose useful fact is the day offset rather than the hour.
+   Drawn in this product's own terms — mono, hairlines, phosphor. */
 
-/* Digital: one big reading and a quiet date. The size difference IS the
-   hierarchy — no rules, no boxes. */
-.clock-digital { text-align: center; }
-.clock-now {
-    font-family: var(--font-mono); font-size: 26px; letter-spacing: 0.06em;
-    color: var(--soa-accent); line-height: 1.1;
-    text-shadow: 0 0 12px rgba(var(--soa-accent-rgb), 0.35);
-    font-variant-numeric: tabular-nums;
+.clock-strip {
+    display: flex; align-items: flex-start; gap: 4px;
+    /* Never a second row: a narrow sidebar scrolls this strip instead of
+       wrapping it, so the clock's height is the same whatever you put in it. */
+    flex-wrap: nowrap; overflow-x: auto; overscroll-behavior-x: contain;
+    scrollbar-width: none; padding-bottom: 2px;
 }
-.clock-date {
-    margin-top: 3px; font-family: var(--font-mono); font-size: 9.5px;
-    letter-spacing: 0.22em; color: var(--soa-accent-dim);
-}
+.clock-strip::-webkit-scrollbar { height: 0; }
 
-/* The dial. A hairline ring and twelve ticks — no numerals, which at this size
-   are noise. The second hand is the only bright thing on it and the only thing
-   that moves every tick, so the eye finds the clock alive without decoration. */
-.clock-dial { width: 108px; height: 108px; display: block; }
-.dial-ring { fill: none; stroke: var(--soa-line); stroke-width: 0.8; }
-.dial-tick { stroke: var(--soa-accent-dim); stroke-width: 1; opacity: 0.55; }
-.dial-tick.major { stroke: var(--soa-accent); stroke-width: 1.4; opacity: 0.9; }
-.dial-h { stroke: var(--soa-accent); stroke-width: 2.6; stroke-linecap: round; }
-.dial-m { stroke: var(--soa-accent); stroke-width: 1.6; stroke-linecap: round; opacity: 0.85; }
-.dial-s {
-    stroke: var(--soa-red); stroke-width: 0.7; stroke-linecap: round;
-    filter: drop-shadow(0 0 2px rgba(var(--soa-accent-rgb), 0.5));
-}
-.dial-pin { fill: var(--soa-accent); }
-
-/* World clock, laid out across rather than down. A stack of four rows reads as
-   a list you have to work through; four columns reads as one glance, which is
-   all anyone wants from a row of city times. Columns are auto-fit, so the same
-   markup gives four across a wide sidebar and two across a narrow one instead
-   of squeezing to illegibility. */
-.clock-cities {
-    display: grid; grid-template-columns: repeat(auto-fit, minmax(48px, 1fr));
-    gap: 4px 6px; padding-top: 2px;
-    border-top: 1px dashed var(--soa-line-soft);
-}
 .city {
-    display: flex; flex-direction: column; gap: 1px; min-width: 0;
-    font-family: var(--font-mono);
+    display: flex; flex-direction: column; align-items: flex-start; gap: 1px;
+    flex: 1 1 0; min-width: 0; font-family: var(--font-mono);
 }
 .city-k {
-    font-size: 8px; letter-spacing: 0.14em; color: var(--soa-accent-dim);
-    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+    font-size: 7.5px; letter-spacing: 0.06em; color: var(--soa-accent-dim);
+    /* City names wrap rather than ellipsing. An ellipsis on a two-word label
+       reads as a bug, and NEW YOR… is worse than two short lines. The block is
+       a fixed two lines tall so every dial below it still starts at the same
+       y — the alignment is what makes the row scannable. */
+    max-width: 100%; white-space: normal; line-height: 1.15;
+    height: 2.3em; overflow: hidden;
+    display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical;
 }
-/* The time is the value; everything around it is a caption. */
-.city-v {
-    font-size: 12px; color: var(--soa-fg); font-variant-numeric: tabular-nums;
-    line-height: 1.15;
+.city-v { font-size: 12px; color: var(--soa-fg); font-variant-numeric: tabular-nums; line-height: 1.15; }
+/* Local is the one you actually live in, so it gets the accent and a touch of
+   the phosphor the rest do not. Nothing else changes — same cell, same size. */
+.city--local .city-k { color: var(--soa-accent); }
+.city--local .city-v {
+    color: var(--soa-accent);
+    text-shadow: 0 0 8px rgba(var(--soa-accent-rgb), 0.3);
 }
-/* Riding the baseline of the time rather than owning a column of its own: it
-   only appears when the day differs, and an empty column would still cost
-   width on every city that agrees with you. */
-.city-d {
-    font-size: 8.5px; color: var(--soa-yellow); line-height: 1;
-    margin-top: 1px; min-height: 8px;
-}
+/* Riding under the time rather than owning a column: it only appears when the
+   day differs, and an empty column would cost width on every city that agrees. */
+.city-d { font-size: 8px; color: var(--soa-yellow); line-height: 1; min-height: 8px; }
+
+/* A dial small enough to stand in a column beside four others. Four quarter
+   ticks, not twelve — at 40px twelve is a smudge — and the second hand is the
+   only saturated thing on the face. */
+.clock-dial { width: 100%; max-width: 38px; height: auto; aspect-ratio: 1; display: block; margin: 1px 0; }
+.dial-ring { fill: none; stroke: var(--soa-line); stroke-width: 1.5; }
+.dial-tick { stroke: var(--soa-accent-dim); stroke-width: 2; opacity: 0.5; }
+.dial-tick.major { stroke: var(--soa-accent-dim); stroke-width: 2.5; opacity: 0.75; }
+.dial-h { stroke: var(--soa-fg); stroke-width: 5; stroke-linecap: round; }
+.dial-m { stroke: var(--soa-fg); stroke-width: 3.2; stroke-linecap: round; opacity: 0.9; }
+.dial-s { stroke: var(--soa-red); stroke-width: 1.6; stroke-linecap: round; }
+.dial-pin { fill: var(--soa-accent); }
+.city--local .dial-h, .city--local .dial-m { stroke: var(--soa-accent); }
+.city--local .dial-ring { stroke: rgba(var(--soa-accent-rgb), 0.45); }
 
 /* ── The secondary menu ─────────────────────────────────────────────── */
 .clock-cfg {

--- a/web/public/assets/widgets.js
+++ b/web/public/assets/widgets.js
@@ -261,12 +261,24 @@ function _segmented(value, options, onPick) {
     return wrap;
 }
 
+// Hours/minutes/seconds in a zone, as numbers. en-GB 24h is the shortest way
+// to a parseable string, and one call covers both the digits and the hands.
+function _hmsIn(now, tz) {
+    try {
+        const s = now.toLocaleTimeString('en-GB', {
+            timeZone: tz, hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit',
+        });
+        const [h, m, sec] = s.split(':').map(Number);
+        return { h, m, s: sec };
+    } catch (_) { return null; }
+}
+
 class ClockWidget extends Widget {
     constructor({ parent }) {
         super({ titleKey: 'widget.clock', parent, intervalMs: 1000 });
 
-        // ⚙ — the secondary menu. Same affordance as the ⓘ the other widgets
-        // carry, so the header keeps one grammar.
+        // ⚙ — the secondary menu. Same affordance the other widgets carry for
+        // ⓘ, so the header keeps one grammar.
         this._cfgBtn = $el('button', {
             class: 'widget-info-btn', type: 'button', title: tr('widget.clock.configure'),
             'aria-label': tr('widget.clock.configure'), text: '⚙',
@@ -278,13 +290,15 @@ class ClockWidget extends Widget {
         this._cfg.hidden = true;
         this.root.querySelector('.widget-h').after(this._cfg);
 
-        this._face = $el('div', { class: 'clock-face' });
-        this._cities = $el('div', { class: 'clock-cities' });
-        this.body.replaceChildren(this._face, this._cities);
-        this._buildAnalog();
+        // ONE row. Local and every city sit in it as identical cells, so the
+        // clock is a glance rather than a list — and the analog face is not a
+        // separate mode that takes the space above, it is simply what a cell's
+        // value looks like when you choose it.
+        this._strip = $el('div', { class: 'clock-strip' });
+        this.body.replaceChildren(this._strip);
+        this._cells = new Map();
+        this._stripKey = '';
         this._renderCfg();
-        // The panel writes settings and settings redraw the panel: a change made
-        // here, in the Settings modal, or on another device all land the same way.
         this._offSettings = onSettings(() => { if (!this._cfg.hidden) this._renderCfg(); });
     }
 
@@ -299,31 +313,54 @@ class ClockWidget extends Widget {
         if (!this._cfg.hidden) this._renderCfg();
     }
 
-    // ── The dial ─────────────────────────────────────────────────────────
-    // SVG, not canvas: it is three attribute writes a second to move the hands
-    // and it stays crisp at any DPR without a redraw. The face is a hairline
-    // ring and twelve ticks — no numerals, because at this size numerals are
-    // noise and the glow is what makes it legible anyway.
-    _buildAnalog() {
+    // A dial small enough to sit in a column beside four others. A hairline
+    // ring and four quarter ticks — at this size twelve of them are a smudge —
+    // and the second hand is the only saturated thing on it.
+    _makeDial() {
         const NS = 'http://www.w3.org/2000/svg';
-        const el = (n, a) => { const e = document.createElementNS(NS, n); for (const k in a) e.setAttribute(k, a[k]); return e; };
-        const svg = el('svg', { class: 'clock-dial', viewBox: '0 0 100 100', 'aria-hidden': 'true' });
-        svg.appendChild(el('circle', { class: 'dial-ring', cx: 50, cy: 50, r: 46 }));
-        for (let i = 0; i < 12; i++) {
-            const major = i % 3 === 0;
-            const t = el('line', {
-                class: 'dial-tick' + (major ? ' major' : ''),
-                x1: 50, y1: major ? 8 : 10, x2: 50, y2: major ? 16 : 14,
-                transform: `rotate(${i * 30} 50 50)`,
-            });
-            svg.appendChild(t);
+        const mk = (n, a) => { const e = document.createElementNS(NS, n); for (const k in a) e.setAttribute(k, a[k]); return e; };
+        const svg = mk('svg', { class: 'clock-dial', viewBox: '0 0 100 100', 'aria-hidden': 'true' });
+        svg.appendChild(mk('circle', { class: 'dial-ring', cx: 50, cy: 50, r: 46 }));
+        for (let i = 0; i < 4; i++) {
+            svg.appendChild(mk('line', {
+                class: 'dial-tick major', x1: 50, y1: 6, x2: 50, y2: 16,
+                transform: `rotate(${i * 90} 50 50)`,
+            }));
         }
-        this._hHand = el('line', { class: 'dial-h', x1: 50, y1: 50, x2: 50, y2: 28 });
-        this._mHand = el('line', { class: 'dial-m', x1: 50, y1: 50, x2: 50, y2: 18 });
-        this._sHand = el('line', { class: 'dial-s', x1: 50, y1: 56, x2: 50, y2: 14 });
-        svg.append(this._hHand, this._mHand, this._sHand);
-        svg.appendChild(el('circle', { class: 'dial-pin', cx: 50, cy: 50, r: 1.6 }));
-        this._dial = svg;
+        const h = mk('line', { class: 'dial-h', x1: 50, y1: 50, x2: 50, y2: 30 });
+        const m = mk('line', { class: 'dial-m', x1: 50, y1: 50, x2: 50, y2: 18 });
+        const sec = mk('line', { class: 'dial-s', x1: 50, y1: 58, x2: 50, y2: 14 });
+        svg.append(h, m, sec);
+        svg.appendChild(mk('circle', { class: 'dial-pin', cx: 50, cy: 50, r: 2.4 }));
+        return { svg, h, m, s: sec };
+    }
+
+    // Cells are rebuilt only when the city list or the face changes — never on
+    // a tick, which just moves hands and swaps text.
+    _ensureCells(keys, face) {
+        const sig = face + '|' + keys.join(',');
+        if (sig === this._stripKey) return;
+        this._stripKey = sig;
+        this._cells.clear();
+        const nodes = [];
+        for (const k of keys) {
+            const label = $el('span', { class: 'city-k', text: k.label });
+            const cell = { root: null, label };
+            const kids = [label];
+            if (face === 'analog') {
+                cell.dial = this._makeDial();
+                kids.push(cell.dial.svg);
+            } else {
+                cell.value = $el('span', { class: 'city-v' });
+                kids.push(cell.value);
+            }
+            cell.delta = $el('span', { class: 'city-d' });
+            kids.push(cell.delta);
+            cell.root = $el('div', { class: 'city' + (k.tz ? '' : ' city--local') }, kids);
+            nodes.push(cell.root);
+            this._cells.set(k.key, cell);
+        }
+        this._strip.replaceChildren(...nodes);
     }
 
     _renderCfg() {
@@ -334,12 +371,10 @@ class ClockWidget extends Widget {
         const chips = $el('div', { class: 'cfg-chips' });
         for (const z of zones) {
             chips.appendChild($el('button', {
-                class: 'chip', type: 'button', title: z,
-                text: _zoneLabel(z) + ' ✕',
+                class: 'chip', type: 'button', title: z, text: _zoneLabel(z) + ' ✕',
                 onclick: () => saveSettings({ clockZones: zones.filter(x => x !== z) }),
             }));
         }
-
         const picker = $el('select', { class: 'cfg-add' });
         picker.appendChild($el('option', { value: '', text: '+ add city' }));
         for (const z of ZONE_PRESETS) {
@@ -347,8 +382,7 @@ class ClockWidget extends Widget {
             picker.appendChild($el('option', { value: z, text: _zoneLabel(z) }));
         }
         picker.addEventListener('change', () => {
-            if (!picker.value) return;
-            saveSettings({ clockZones: [...zones, picker.value] });
+            if (picker.value) saveSettings({ clockZones: [...zones, picker.value] });
         });
 
         this._cfg.replaceChildren(
@@ -363,54 +397,40 @@ class ClockWidget extends Widget {
     tick() {
         const now = new Date();
         const s = getSettings();
+        const analog = s.clockFace === 'analog';
         const hours12 = s.clockHours === 12;
 
-        if (s.clockFace === 'analog') {
-            if (this._face.firstElementChild !== this._dial) this._face.replaceChildren(this._dial);
-            const ms = now.getMilliseconds();
-            const sec = now.getSeconds() + ms / 1000;
-            const min = now.getMinutes() + sec / 60;
-            const hr = (now.getHours() % 12) + min / 60;
-            this._sHand.setAttribute('transform', `rotate(${sec * 6} 50 50)`);
-            this._mHand.setAttribute('transform', `rotate(${min * 6} 50 50)`);
-            this._hHand.setAttribute('transform', `rotate(${hr * 30} 50 50)`);
-        } else {
-            const time = hours12
-                ? now.toLocaleTimeString('en-US', { hour12: true, hour: 'numeric', minute: '2-digit', second: '2-digit' })
-                : now.toTimeString().slice(0, 8);
-            if (!this._digital || this._face.firstElementChild !== this._digital) {
-                this._digital = $el('div', { class: 'clock-digital' }, [
-                    this._dTime = $el('div', { class: 'clock-now' }),
-                    this._dDate = $el('div', { class: 'clock-date' }),
-                ]);
-                this._face.replaceChildren(this._digital);
-            }
-            this._dTime.textContent = time;
-            this._dDate.textContent = now.toISOString().slice(0, 10);
-        }
+        const keys = [{ key: '@local', label: 'LOCAL', tz: null }];
+        for (const tz of (s.clockZones || [])) keys.push({ key: tz, label: _zoneLabel(tz), tz });
+        this._ensureCells(keys, analog ? 'analog' : 'digital');
 
-        // The city list is the same in both faces. Each carries the day it is
-        // on relative to here, and nothing when the two agree — the hour alone
-        // does not tell you whether you can call.
         const hereYmd = _ymdIn(now, undefined) || now.toISOString().slice(0, 10);
-        const rows = [];
-        for (const tz of (s.clockZones || [])) {
-            let t;
-            try {
-                t = now.toLocaleTimeString('en-US', { timeZone: tz, hour12: hours12, hour: '2-digit', minute: '2-digit' });
-            } catch (_) { continue; }
-            const thereYmd = _ymdIn(now, tz);
-            let delta = 0;
-            if (thereYmd && hereYmd) {
-                delta = Math.round((Date.parse(thereYmd + 'T00:00:00Z') - Date.parse(hereYmd + 'T00:00:00Z')) / 86400000);
+        for (const k of keys) {
+            const cell = this._cells.get(k.key);
+            if (!cell) continue;
+            const hms = k.tz ? _hmsIn(now, k.tz) : { h: now.getHours(), m: now.getMinutes(), s: now.getSeconds() };
+            if (!hms) continue;
+
+            if (cell.dial) {
+                const sec = hms.s, min = hms.m + sec / 60, hr = (hms.h % 12) + min / 60;
+                cell.dial.s.setAttribute('transform', `rotate(${sec * 6} 50 50)`);
+                cell.dial.m.setAttribute('transform', `rotate(${min * 6} 50 50)`);
+                cell.dial.h.setAttribute('transform', `rotate(${hr * 30} 50 50)`);
+            } else if (cell.value) {
+                let h = hms.h, suffix = '';
+                if (hours12) { suffix = h >= 12 ? 'p' : 'a'; h = h % 12 || 12; }
+                cell.value.textContent =
+                    `${hours12 ? h : String(h).padStart(2, '0')}:${String(hms.m).padStart(2, '0')}${suffix}`;
             }
-            rows.push($el('div', { class: 'city' + (delta ? ' shifted' : '') }, [
-                $el('span', { class: 'city-k', text: _zoneLabel(tz) }),
-                $el('span', { class: 'city-v', text: t }),
-                $el('span', { class: 'city-d', text: delta > 0 ? `+${delta}d` : delta < 0 ? `${delta}d` : '' }),
-            ]));
+
+            // The day offset only appears when it changes the answer.
+            let delta = 0;
+            if (k.tz) {
+                const thereYmd = _ymdIn(now, k.tz);
+                if (thereYmd) delta = Math.round((Date.parse(thereYmd + 'T00:00:00Z') - Date.parse(hereYmd + 'T00:00:00Z')) / 86400000);
+            }
+            cell.delta.textContent = delta > 0 ? `+${delta}d` : delta < 0 ? `${delta}d` : '';
         }
-        this._cities.replaceChildren(...rows);
     }
 }
 


### PR DESCRIPTION
The analog face used to be a *mode* that took the space above the city list. Now local and every city are **identical cells in a single row**, and the dial is simply what a cell's value looks like when you choose that face — which is why five dials fit where one used to.

```
LOCAL   NEW      LONDON   TOKYO    UTC
        YORK
 ◔        ◔        ◔        ◔       ◔
                            +1d
```

- **Local is the same cell as the others**, just carrying the accent and a little phosphor. Making it bigger would have re-created the hierarchy this was meant to flatten.
- **The strip never wraps.** A sidebar too narrow for the set scrolls it rather than growing a second row, so the widget's height does not depend on how many cities you keep.
- **Labels wrap to two fixed lines rather than ellipsing.** `NEW YOR…` reads as a bug, not a truncation. The fixed height keeps every dial starting at the same y, which is the thing that makes a row scannable at all.
- **Four quarter ticks, not twelve.** At 38px twelve ticks are a smudge.
- The day offset still rides under the time and still only appears when it changes the answer.

Cells are rebuilt only when the city list or the face changes — a tick moves three hand transforms per cell and swaps text, nothing more.

Verified live: 5 cells, 1 row, dials aligned, no horizontal overflow, no clipped labels, 69px tall.