### PR TITLE
ui(skins): give MINIMAL and LIQUID the new components

### DIFF
--- a/web/public/assets/liquid.css
+++ b/web/public/assets/liquid.css
@@ -517,3 +517,50 @@
 @media (prefers-reduced-motion: reduce) {
   [data-ui="liquid"] .tab.active::after { animation: none; }
 }
+
+/* ── Settings, segmented controls, clock ─────────────────────────────────
+   Same components, this skin's material. Nothing here is decoration for its
+   own sake: the frost separates a control from the terminal light behind it,
+   and the specular rim is what tells you a segment is raised rather than
+   printed. Radii come from the squircle scale so these sit with everything
+   else, and the type is SF Pro like the rest of the chrome. */
+
+[data-ui="liquid"] .set-label { font-family: var(--font-display); font-weight: 500; font-size: 13px; letter-spacing: -0.01em; }
+[data-ui="liquid"] .set-key { color: rgba(255, 255, 255, 0.32); }
+[data-ui="liquid"] .set-desc { font-family: var(--font-display); font-size: 11.5px; line-height: 1.5; color: rgba(255, 255, 255, 0.55); }
+[data-ui="liquid"] .set-row { border-bottom: 1px solid rgba(255, 255, 255, 0.07); }
+[data-ui="liquid"] .set-row:last-child { border-bottom: none; }
+
+/* Glass track, brighter glass on the chosen segment, specular rim on top. */
+[data-ui="liquid"] .seg {
+  background: var(--lq-glass); border: 1px solid var(--lq-edge);
+  border-radius: var(--lq-r-sm); padding: 2px;
+  backdrop-filter: var(--lq-blur); -webkit-backdrop-filter: var(--lq-blur);
+}
+[data-ui="liquid"] .seg-o {
+  font-family: var(--font-display); font-weight: 500; font-size: 11px;
+  letter-spacing: 0; border-radius: var(--lq-r-xs); color: var(--soa-accent-dim);
+}
+[data-ui="liquid"] .seg-o + .seg-o { border-left: none; }
+[data-ui="liquid"] .seg-o.on {
+  background: var(--lq-fill-2); color: var(--soa-fg); text-shadow: none;
+  box-shadow: var(--lq-rim);
+}
+
+[data-ui="liquid"] :is(.cfg-k, .city-k) {
+  font-family: var(--font-display); letter-spacing: 0.02em; font-size: 10px;
+  color: var(--soa-accent-dim);
+}
+[data-ui="liquid"] .city-v { font-family: var(--font-display); font-weight: 500; }
+[data-ui="liquid"] .city--local .city-v { color: #fff; text-shadow: 0 0 14px rgba(255, 255, 255, 0.35); }
+[data-ui="liquid"] :is(.chip, .cfg-add) {
+  font-family: var(--font-display); letter-spacing: 0;
+  background: var(--lq-glass); border: 1px solid var(--lq-edge); color: var(--soa-fg);
+  border-radius: 999px;
+  backdrop-filter: var(--lq-blur); -webkit-backdrop-filter: var(--lq-blur);
+}
+[data-ui="liquid"] .cfg-add { border-radius: var(--lq-r-xs); }
+[data-ui="liquid"] :is(.dial-h, .dial-m) { stroke: #fff; }
+[data-ui="liquid"] .dial-ring { stroke: rgba(255, 255, 255, 0.18); }
+[data-ui="liquid"] .dial-tick { stroke: rgba(255, 255, 255, 0.3); }
+[data-ui="liquid"] .clock-cfg { border-bottom: 1px solid rgba(255, 255, 255, 0.07); }

--- a/web/public/assets/minimal.css
+++ b/web/public/assets/minimal.css
@@ -445,3 +445,59 @@
 
 /* ── Mobile-sim modal frame ── */
 [data-ui="minimal"] .msim-frame { border-radius: 18px; overflow: hidden; box-shadow: var(--m-shadow-deep); }
+
+/* ── Settings, segmented controls, clock ─────────────────────────────────
+   The components added for the settings list, the ON/OFF switch and the clock
+   were built in TRON's idiom: mono type, uppercase micro-labels, phosphor. The
+   tokens carry the palette across on their own, but the IDIOM does not — an
+   uppercase mono label on porcelain reads as a machine label on a printed page.
+   Here they take this skin's voice: Familjen Grotesk, lowercase structure, ink
+   instead of glow, and a segmented control that is a white card lifting off the
+   porcelain rather than a filled cell. */
+
+[data-ui="minimal"] .set-label {
+  font-family: var(--font-display); font-weight: 500; font-size: 13px;
+  letter-spacing: -0.01em; color: var(--soa-fg);
+}
+[data-ui="minimal"] .set-key { color: rgba(34, 37, 43, 0.34); }
+[data-ui="minimal"] .set-desc {
+  font-family: var(--font-display); font-size: 11.5px; line-height: 1.5;
+  color: rgba(34, 37, 43, 0.6);
+}
+/* Porcelain is a crisper ground than phosphor: a solid hairline, not a dash. */
+[data-ui="minimal"] .set-row { border-bottom: 1px solid var(--soa-line); }
+[data-ui="minimal"] .set-row:last-child { border-bottom: none; }
+
+/* The segmented control, light-mode: a recessed track with the chosen option
+   riding above it as a white card. Shadow does the work colour does in TRON. */
+[data-ui="minimal"] .seg {
+  background: rgba(34, 37, 43, 0.06);
+  border: 1px solid var(--soa-line); border-radius: 8px; padding: 2px;
+}
+[data-ui="minimal"] .seg-o {
+  font-family: var(--font-display); font-weight: 500; font-size: 11px;
+  letter-spacing: 0; text-transform: lowercase; border-radius: 6px;
+  color: rgba(34, 37, 43, 0.55);
+}
+[data-ui="minimal"] .seg-o + .seg-o { border-left: none; }
+[data-ui="minimal"] .seg-o.on {
+  background: #ffffff; color: var(--soa-fg); text-shadow: none;
+  box-shadow: 0 1px 2px rgba(34, 37, 43, 0.12), 0 0 0 1px rgba(34, 37, 43, 0.05);
+}
+
+[data-ui="minimal"] :is(.cfg-k, .city-k) {
+  font-family: var(--font-display); text-transform: lowercase;
+  letter-spacing: 0; font-size: 10px; color: rgba(34, 37, 43, 0.5);
+}
+[data-ui="minimal"] .city-v { font-family: var(--font-display); font-weight: 500; color: var(--soa-fg); }
+[data-ui="minimal"] .city--local .city-v { color: var(--soa-accent); text-shadow: none; }
+[data-ui="minimal"] :is(.chip, .cfg-add) {
+  font-family: var(--font-display); text-transform: lowercase; letter-spacing: 0;
+  background: #ffffff; border: 1px solid var(--soa-line); color: rgba(34, 37, 43, 0.7);
+}
+/* Ink hands on a paper dial — the glow that reads as "lit" on black reads as
+   smudged printing on porcelain. */
+[data-ui="minimal"] :is(.dial-h, .dial-m) { stroke: var(--soa-fg); }
+[data-ui="minimal"] .dial-ring { stroke: rgba(34, 37, 43, 0.22); }
+[data-ui="minimal"] .dial-tick { stroke: rgba(34, 37, 43, 0.3); }
+[data-ui="minimal"] .clock-cfg { border-bottom: 1px solid var(--soa-line); }

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -156,8 +156,8 @@
   <link rel="apple-touch-icon" href="/assets/New-icon-transparent.png?v=3">
   <link rel="stylesheet" href="/assets/styles.css?v=91">
   <link rel="stylesheet" href="/assets/sidebar.css?v=45">
-  <link rel="stylesheet" href="/assets/minimal.css?v=4">
-  <link rel="stylesheet" href="/assets/liquid.css?v=10">
+  <link rel="stylesheet" href="/assets/minimal.css?v=5">
+  <link rel="stylesheet" href="/assets/liquid.css?v=11">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@5.3.0/css/xterm.css">
   <script src="/_config.js"></script>
   <script>


### PR DESCRIPTION
Everything built this session — the settings list, the ON/OFF switch, the clock strip and dial, the city chips, the config panel — existed only in TRON's idiom. The `--soa-*` tokens carried the *palette* across on their own, which is why nothing looked broken, but the **idiom** did not: an uppercase mono micro-label with a phosphor glow reads as a machine label stamped on porcelain, and a flat filled cell reads as printed rather than raised on glass.

**MINIMAL** — Familjen Grotesk, lowercase structural labels, solid hairlines rather than dashes (porcelain is a crisper ground than phosphor), ink hands on the dial with the glow removed, and a segmented control that is a **white card lifting off a recessed track**: shadow doing the work colour does in TRON.

**LIQUID** — SF Pro, squircle radii drawn from the skin's existing `--lq-r-*` scale, a **frosted track with the chosen segment on brighter glass under the specular rim**, and glass pills for the city chips. The frost is not decoration: it is what separates a control from the terminal light behind it.

Both verified by rendering the settings modal in each skin.

Audited alongside this, since it had to be true before restyling: **all seven settings tabs are functional.** Every pane renders, no error states, no unintended disabled controls, all thirteen `set-*` ids the save path reads are present, and a full round-trip through the new segmented switch — click OFF → hidden input `false` → Save → persisted `false` — works.