### PR TITLE
ui(skins): canvas, recovery panel and bands in MINIMAL and LIQUID

### DIFF
--- a/web/public/assets/liquid.css
+++ b/web/public/assets/liquid.css
@@ -564,3 +564,51 @@
 [data-ui="liquid"] .dial-ring { stroke: rgba(255, 255, 255, 0.18); }
 [data-ui="liquid"] .dial-tick { stroke: rgba(255, 255, 255, 0.3); }
 [data-ui="liquid"] .clock-cfg { border-bottom: 1px solid rgba(255, 255, 255, 0.07); }
+
+/* ── Context canvas, recovery panel, transcript bands ────────────────────
+   The last Tron-only surfaces. The palette came across with the tokens; the
+   material did not — and the band overlay was still positioned to TRON's
+   terminal padding rather than this skin's thin glass rim, so every band sat a
+   few pixels off the text it belonged to. */
+
+[data-ui="liquid"] :is(.ctx-brand, .ctx-band-h) {
+  font-family: var(--font-display); letter-spacing: 0.04em; font-weight: 590;
+  color: var(--soa-accent-dim); text-shadow: none;
+}
+[data-ui="liquid"] .ctx-head { border-bottom: 1px solid rgba(255, 255, 255, 0.08); }
+[data-ui="liquid"] :is(.ctx-turns, .ctx-sub, .ctx-muted, .ctx-fact-k, .ctx-turn-n, .ctx-turn-t) {
+  color: var(--soa-accent-dim);
+}
+[data-ui="liquid"] .ctx-turn-x { font-family: var(--font-display); color: rgba(255, 255, 255, 0.86); }
+/* The current turn is the one raised piece of glass in the column. */
+[data-ui="liquid"] .ctx-turn.latest {
+  background: var(--lq-glass-2); border-radius: var(--lq-r-xs); box-shadow: var(--lq-rim);
+}
+[data-ui="liquid"] :is(.ctx-art-t, .ctx-step-x) { font-family: var(--font-display); }
+[data-ui="liquid"] .ctx-step-add { font-family: var(--font-display); border-radius: var(--lq-r-xs); }
+[data-ui="liquid"] .ctx-pull::before { background: rgba(255, 255, 255, 0.35); }
+[data-ui="liquid"] .ctx-pull:hover {
+  background-color: var(--lq-glass-2); box-shadow: var(--lq-rim);
+}
+
+/* Recovery: the one moment the interface has to be unmissable, so it is the
+   most opaque glass in the product — readable even over a busy terminal. */
+[data-ui="liquid"] .recovery {
+  background: rgba(28, 28, 32, 0.82); border: 1px solid var(--lq-edge);
+  border-radius: var(--lq-r); box-shadow: var(--lq-shadow-deep), var(--lq-rim);
+  backdrop-filter: var(--lq-blur-lg); -webkit-backdrop-filter: var(--lq-blur-lg);
+}
+[data-ui="liquid"] .recovery-head h2 {
+  font-family: var(--font-display); letter-spacing: 0.02em; color: #ffd60a;
+}
+[data-ui="liquid"] :is(.recovery-lead, .recovery-body p, .recovery-body h3) { font-family: var(--font-display); }
+[data-ui="liquid"] .recovery-pulse {
+  background: var(--lq-glass); border-left-color: rgba(255, 255, 255, 0.4);
+  border-radius: 0 var(--lq-r-xs) var(--lq-r-xs) 0;
+}
+[data-ui="liquid"] :is(.recovery-cmd code, .recovery-copy) {
+  background: var(--lq-glass); border: 1px solid var(--lq-edge); border-radius: var(--lq-r-xs);
+}
+
+/* Aligned to this skin's terminal rim rather than TRON's. */
+[data-ui="liquid"] .term-bands { inset: 8px 6px; }

--- a/web/public/assets/minimal.css
+++ b/web/public/assets/minimal.css
@@ -501,3 +501,58 @@
 [data-ui="minimal"] .dial-ring { stroke: rgba(34, 37, 43, 0.22); }
 [data-ui="minimal"] .dial-tick { stroke: rgba(34, 37, 43, 0.3); }
 [data-ui="minimal"] .clock-cfg { border-bottom: 1px solid var(--soa-line); }
+
+/* ── Context canvas, recovery panel, transcript bands ────────────────────
+   The last Tron-only surfaces. Two of these are not merely unstyled here —
+   they are WRONG here, and only in this skin, because both were written
+   against a phosphor accent on black:
+
+   the transcript band tints with the accent, and MINIMAL's accent is ink, so
+   screen-blending it over the dark slate produced nothing at all — the bands
+   were invisible; and the band overlay is positioned to TRON's terminal
+   padding, while MINIMAL insets its terminal as a slate card with its own,
+   so every band sat a few pixels off the text it belonged to. */
+
+/* Canvas: a sheet of paper beside the slate, not a lit panel. */
+[data-ui="minimal"] :is(.ctx-brand, .ctx-band-h) {
+  font-family: var(--font-display); text-transform: lowercase;
+  letter-spacing: 0; font-weight: 500; color: rgba(34, 37, 43, 0.45);
+  text-shadow: none;
+}
+[data-ui="minimal"] .ctx-head { border-bottom: 1px solid var(--soa-line); }
+[data-ui="minimal"] :is(.ctx-turns, .ctx-sub, .ctx-muted, .ctx-fact-k, .ctx-turn-n, .ctx-turn-t) {
+  color: rgba(34, 37, 43, 0.45);
+}
+[data-ui="minimal"] .ctx-turn-x { font-family: var(--font-display); color: rgba(34, 37, 43, 0.82); }
+[data-ui="minimal"] .ctx-fact-v { color: var(--soa-fg); }
+[data-ui="minimal"] .ctx-turn.latest { background: rgba(34, 37, 43, 0.045); }
+[data-ui="minimal"] :is(.ctx-art-t, .ctx-step-x) { font-family: var(--font-display); color: var(--soa-fg); }
+[data-ui="minimal"] .ctx-step-add { font-family: var(--font-display); text-transform: lowercase; }
+/* The pull tab is furniture on paper: a hairline grip, no glow. */
+[data-ui="minimal"] .ctx-pull::before { background: rgba(34, 37, 43, 0.28); }
+[data-ui="minimal"] .ctx-pull:hover { box-shadow: none; background-color: #fff; }
+
+/* Recovery: a notice card, which is what porcelain does instead of an alarm. */
+[data-ui="minimal"] .recovery {
+  background: #fff; border: 1px solid var(--soa-line);
+  border-radius: 12px; box-shadow: var(--m-shadow-deep);
+}
+[data-ui="minimal"] .recovery-head h2 {
+  font-family: var(--font-display); text-transform: lowercase; letter-spacing: 0;
+  font-weight: 600; color: #a8621b;
+}
+[data-ui="minimal"] :is(.recovery-lead, .recovery-body p, .recovery-body h3) { font-family: var(--font-display); }
+[data-ui="minimal"] .recovery-pulse {
+  background: rgba(34, 37, 43, 0.05); border-left-color: rgba(34, 37, 43, 0.3);
+  color: rgba(34, 37, 43, 0.7);
+}
+[data-ui="minimal"] .recovery-cmd code { background: rgba(34, 37, 43, 0.05); color: var(--soa-fg); }
+
+/* Bands: aligned to THIS skin's terminal padding, and tinted with light rather
+   than ink so screen-blending over the dark slate actually shows. */
+[data-ui="minimal"] .term-bands { inset: 12px 14px 14px; }
+[data-ui="minimal"] .term-band[data-kind="user"] {
+  background: linear-gradient(90deg,
+      rgba(255, 255, 255, 0.16) 0%, rgba(255, 255, 255, 0.09) 55%, rgba(255, 255, 255, 0.03) 100%);
+  box-shadow: inset 3px 0 0 rgba(255, 255, 255, 0.55);
+}

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -156,8 +156,8 @@
   <link rel="apple-touch-icon" href="/assets/New-icon-transparent.png?v=3">
   <link rel="stylesheet" href="/assets/styles.css?v=91">
   <link rel="stylesheet" href="/assets/sidebar.css?v=45">
-  <link rel="stylesheet" href="/assets/minimal.css?v=5">
-  <link rel="stylesheet" href="/assets/liquid.css?v=11">
+  <link rel="stylesheet" href="/assets/minimal.css?v=6">
+  <link rel="stylesheet" href="/assets/liquid.css?v=12">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@5.3.0/css/xterm.css">
   <script src="/_config.js"></script>
   <script>


### PR DESCRIPTION
The remaining Tron-only surfaces: the context canvas (33 classes, none themed), the recovery panel, and the transcript bands. Two of them were not merely unstyled in the other skins — they were **wrong**, and only there.

**The bands were invisible in MINIMAL.** They tint with `--soa-accent` and screen-blend it. Screen only ever lightens, and MINIMAL's accent is ink `#22252b` — blending near-black over the dark slate produces nothing. They now tint with light in that skin.

**The band overlay was aligned to Tron's terminal padding in every skin.** `.term-bands` uses `inset: 4px 0 4px 6px` to match Tron's `.term` padding — but MINIMAL insets its terminal as a slate card with `padding: 12px 14px`, and LIQUID uses a thin glass rim with `padding: 8px 6px`. Every band sat several pixels off the text it belonged to. Each skin now matches its own.

**The canvas** takes each skin's voice: lowercase Familjen Grotesk on paper for MINIMAL, SF Pro for LIQUID with the current turn raised on glass under the specular rim rather than merely tinted.

**The recovery panel** becomes a notice card on porcelain, and the most opaque glass in the product on liquid — it is the one moment the interface has to be unmissable, so it is the one place the blur goes heavy.

Verification note: the settings-modal pass in #43 was rendered and checked in both skins. This pass was **not** — the agent browser stopped completing its boot partway through (the skin attribute and stylesheets load, `data-ui=liquid`, but the app shell does not come up), so the inset values here are derived from each skin's own declared `.term` padding rather than measured on screen.