### PR TITLE
fix(term): trust the paint over xterm's reported cell width

### DIFF
--- a/web/public/assets/app.js
+++ b/web/public/assets/app.js
@@ -625,6 +625,30 @@ class TabRuntime {
             const core = this.term._core;
             const dims = core && core._renderService && core._renderService.dimensions;
             let cellW = dims && dims.css && dims.css.cell && dims.css.cell.width;
+            // Cross-check xterm's own number against what it actually PAINTED.
+            // The painted grid is exactly cols x cellW, so dividing it gives the
+            // true cell width — and when the two disagree, the paint is the one
+            // that is on screen. This is the case the earlier fallbacks never
+            // caught: they only ran when the lookup returned nothing, and a
+            // lookup that returns a WRONG number (a stale metric from before the
+            // web font landed, a device-pixel value on a 2x display) sails
+            // through, undercounts the columns, and strands the right-hand
+            // third of the terminal as black.
+            let painted = 0;
+            if (this.term.element && this.term.cols > 0) {
+                for (const c of this.term.element.querySelectorAll('.xterm-screen canvas')) {
+                    const w = c.getBoundingClientRect().width;
+                    if (w > painted) painted = w;
+                }
+                if (!painted) {
+                    const rowsEl = this.term.element.querySelector('.xterm-rows');
+                    if (rowsEl) painted = rowsEl.getBoundingClientRect().width;
+                }
+                painted = painted / this.term.cols;
+            }
+            if (painted > 0.5 && (!(cellW > 0.5) || Math.abs(cellW - painted) / painted > 0.05)) {
+                cellW = painted;
+            }
             // xterm moves its dimension bookkeeping between versions, and when
             // this lookup misses, FitAddon's own proposeDimensions misses with
             // it — fit() silently becomes a no-op and the grid stays frozen at
@@ -643,14 +667,6 @@ class TabRuntime {
             // how the right-hand strip came back the moment a GPU renderer was
             // switched on. The painted canvas is exactly cols x cellW, so divide
             // it: renderer-derived, no font guessing, no rounding drift.
-            if (!(cellW > 0.5) && this.term.element && this.term.cols > 0) {
-                let widest = 0;
-                for (const c of this.term.element.querySelectorAll('.xterm-screen canvas')) {
-                    const w = c.getBoundingClientRect().width;
-                    if (w > widest) widest = w;
-                }
-                if (widest > 0) cellW = widest / this.term.cols;
-            }
             // Last resort: measure the font itself. Uses the Terminal's own
             // options rather than computed style, which can report the stylesheet
             // default instead of the face xterm is actually rendering with.

--- a/web/public/assets/sidebar.css
+++ b/web/public/assets/sidebar.css
@@ -436,7 +436,9 @@
     border-left: 1px solid var(--soa-line);
     background: var(--soa-bg-panel);
     display: flex; flex-direction: column;
-    min-width: 0; overflow: hidden;
+    /* With every band holding a floor, the column can exceed the panel — so the
+       panel scrolls rather than silently eating the bands at the bottom. */
+    min-width: 0; overflow-x: hidden; overflow-y: auto;
 }
 .stage.no-context .context-panel { display: none; }
 
@@ -558,8 +560,12 @@
 }
 .ctx-turn.latest .ctx-turn-x { max-height: none; }
 
+/* Every band gets enough default height to show its content instead of
+   collapsing to one scrolling line. WORKSPACE has four facts and was showing
+   one; a band whose whole purpose is four values should not need scrolling to
+   read four values. */
 .ctx-facts { padding: 2px 12px 9px; display: flex; flex-direction: column; gap: 2px;
-    min-height: 0; overflow-y: auto; }
+    min-height: 66px; overflow-y: auto; }
 .ctx-fact { display: grid; grid-template-columns: 52px 1fr; gap: 8px;
     font-family: var(--font-mono); font-size: 10px; align-items: baseline; }
 .ctx-fact-k { color: var(--soa-accent-dim); letter-spacing: 0.12em; }
@@ -569,7 +575,7 @@
 /* ARTIFACTS: one line per published thing, newest first. The row is the link —
    a whole-row target beats a small anchor at this type size. */
 .ctx-arts { padding: 2px 6px 8px 12px; display: flex; flex-direction: column; gap: 1px;
-    min-height: 0; max-height: min(24vh, 200px); overflow-y: auto; }
+    min-height: 52px; max-height: min(24vh, 200px); overflow-y: auto; }
 .ctx-art { display: grid; grid-template-columns: 1fr auto; gap: 8px; align-items: baseline;
     padding: 2px 6px 2px 0; font-family: var(--font-mono); font-size: 10.5px;
     color: var(--soa-fg); text-decoration: none; border-left: 2px solid transparent; }
@@ -579,7 +585,7 @@
 .ctx-art-t { font-size: 8.5px; color: var(--soa-accent-dim); opacity: 0.7; }
 
 .ctx-steps { padding: 2px 12px 4px; display: flex; flex-direction: column; gap: 1px;
-    max-height: min(30vh, 260px); overflow-y: auto; }
+    min-height: 56px; max-height: min(30vh, 260px); overflow-y: auto; }
 .ctx-step { display: grid; grid-template-columns: auto 1fr auto; gap: 7px;
     align-items: baseline; font-family: var(--font-mono); font-size: 10.5px; }
 .ctx-step-mark, .ctx-step-del {

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -155,7 +155,7 @@
   <link rel="shortcut icon" href="/assets/New-icon-transparent.png?v=3" type="image/png">
   <link rel="apple-touch-icon" href="/assets/New-icon-transparent.png?v=3">
   <link rel="stylesheet" href="/assets/styles.css?v=91">
-  <link rel="stylesheet" href="/assets/sidebar.css?v=46">
+  <link rel="stylesheet" href="/assets/sidebar.css?v=47">
   <link rel="stylesheet" href="/assets/minimal.css?v=7">
   <link rel="stylesheet" href="/assets/liquid.css?v=12">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@5.3.0/css/xterm.css">


### PR DESCRIPTION
**Why the black strip survived four fixes.** Each one added another *fallback* to `_fillWidth` — `.xterm-rows`, then the painted canvas, then font measurement — and every one of them only ran when xterm's own lookup returned **nothing**. A lookup that returns a *wrong* number sails straight through all of them.

That is what is happening. Every PTY in the fleet is at **102 columns** in a container with room for ~168, and the arithmetic is exact: 1214px ÷ 102 = **11.9px per cell**, against a painted cell of **7.2px**. xterm is reporting a cell width it is not drawing with — a stale metric from before the web font landed, or a device-pixel value on a 2× display.

The painted grid is exactly `cols × cellW`, so dividing it gives the true cell width. It is now the **authority** rather than the last resort: when xterm's number and the paint disagree by more than 5%, the paint wins, because the paint is what is on screen. That also explains why only one terminal looked right — a tab that happened to be fit while the lookup was empty got the correct fallback; the rest got the wrong number.

**Separately, the context canvas bands get default heights.** WORKSPACE holds four facts and was collapsing to a single scrolling line — a band whose whole purpose is four values should not need scrolling to read four values. Floors: facts 66px, artifacts 52px, steps 56px, with PROMPTS still taking the remaining space. With floors in place the column can exceed the panel, so the panel now scrolls instead of silently eating the bands at the bottom.

Verified live: terminal gap 6px (the container padding), and all three bands render their content without scrolling.