### PR TITLE
perf(timemachine): stop freezing the page every five minutes

### DIFF
--- a/web/public/assets/app.js
+++ b/web/public/assets/app.js
@@ -942,7 +942,7 @@ class Shell {
             tmBtn.addEventListener('click', async () => {
                 this.audio.play('panels');
                 try {
-                    const tm = await import('/assets/timemachine.js?v=3');
+                    const tm = await import('/assets/timemachine.js?v=4');
                     tm.openTimemachineModal(this);
                 } catch (err) {
                     console.warn('[timemachine] open failed', err);
@@ -6902,7 +6902,7 @@ async function bootServerMode({ backend, token }) {
         audio.play('theme');
     }, s0.nointro ? 0 : 250);
 
-    import('/assets/timemachine.js?v=3')
+    import('/assets/timemachine.js?v=4')
         .then(tm => tm.startTimemachine(shell))
         .catch(err => console.warn('[timemachine] boot failed', err));
 }

--- a/web/public/assets/timemachine.js
+++ b/web/public/assets/timemachine.js
@@ -147,11 +147,20 @@ async function _prune() {
     for (let i = 0; i < drop; i++) await _delete(all[i].ts);
 }
 
+// Per-tab dump cache. A snapshot re-reads every tab's whole buffer, and on a
+// fleet most tabs have produced nothing since the last one — re-translating
+// their thousand lines is pure waste. buf.length and baseY together move the
+// moment a tab emits anything, so they are a sufficient change stamp.
+const _dumpCache = new Map();   // tab id -> { stamp, text }
+
 function _dumpScrollback(rt) {
     if (!rt || !rt.term) return '';
     try {
         const buf = rt.term.buffer.active;
         const total = buf.length;
+        const stamp = total + ':' + buf.baseY;
+        const hit = _dumpCache.get(rt.id);
+        if (hit && hit.stamp === stamp) return hit.text;
         const start = Math.max(0, total - MAX_LINES_PER_TAB);
         const lines = [];
         for (let y = start; y < total; y++) {
@@ -160,7 +169,9 @@ function _dumpScrollback(rt) {
             lines.push(line.translateToString(true));
         }
         while (lines.length && lines[lines.length - 1] === '') lines.pop();
-        return lines.join('\n');
+        const text = lines.join('\n');
+        _dumpCache.set(rt.id, { stamp, text });
+        return text;
     } catch (_) { return ''; }
 }
 
@@ -177,9 +188,16 @@ export async function snapshotNow(shell) {
     if (!shell) return null;
     const ts = Date.now();
     const tabs = [];
+    // Yield between tabs. Reading a buffer is ~1000 translateToString calls, and
+    // doing twenty-odd of those back to back is a single task long enough to
+    // freeze the page — which is what a snapshot every five minutes felt like.
+    // Broken up, no individual task is long enough to drop a frame.
+    const breathe = () => new Promise(r => setTimeout(r, 0));
+    let n = 0;
     for (const id of shell.order) {
         const rt = shell.tabs.get(id);
         if (!rt) continue;
+        if (n++ > 0) await breathe();
         tabs.push({
             id,
             title: rt.title || `tab #${id}`,


### PR DESCRIPTION
From the console log: snapshots at `1:52:57`, `1:57:27`, `2:02:27`, `2:04:14` — **22 tabs each time**.

`snapshotNow` read every tab's entire buffer in one synchronous pass: roughly a thousand `translateToString()` calls per tab, twenty-two tabs, then a JSON serialise and an IndexedDB write of the result. That is a single task long enough to drop every frame inside it, on a five-minute cadence — which matches "super unresponsive" better than anything else in that log.

**Unchanged tabs are no longer re-read.** Each dump is cached against a change stamp of `buf.length + ':' + buf.baseY`, both of which move the instant a tab emits anything. On a fleet where most tabs are idle between snapshots, most of the work disappears.

**The loop yields between tabs**, so even a full re-read is many short tasks instead of one long one, and no single task is long enough to cost a frame.

Module version bumped so the change actually reaches loaded pages.