### PR TITLE
fix(ctx): measure context from tokens, not from the screen

### DIFF
--- a/server/src/claudeUsage.js
+++ b/server/src/claudeUsage.js
@@ -375,7 +375,16 @@ function compute() {
                 if (meta.slug && (!ss.slug || !meta.side)) ss.slug = meta.slug;
                 if (meta.cwd && (!ss.cwd || !meta.side)) ss.cwd = meta.cwd;
             }
-            if (r.ts > ss.lastTs) ss.lastTs = r.ts;
+            if (r.ts > ss.lastTs) {
+                ss.lastTs = r.ts;
+                // The live CONTEXT size, which is a different quantity from the
+                // token totals beside it: those accumulate over every request,
+                // this is what the model was holding on the most recent one.
+                // input + cache read + cache writes + output IS the context that
+                // request carried, so the newest record is the current context.
+                ss.ctxTokens = (r.input || 0) + (r.cacheRead || 0)
+                    + (r.cw5m || 0) + (r.cw1h || 0) + (r.output || 0);
+            }
             const tok = tokensOf(r);
             for (const [on, scope] of [[inBlock, ss.block], [inToday, ss.today]]) {
                 if (!on) continue;
@@ -472,6 +481,13 @@ function compute() {
             slug: s.slug,
             cwd: s.cwd,
             lastTs: s.lastTs,
+            ctxTokens: s.ctxTokens || 0,
+            // The window is inferred rather than configured: a context that has
+            // already exceeded 200k proves the session is on a 1M model, and
+            // guessing low would report an impossible percentage.
+            ctxPct: s.ctxTokens
+                ? Math.min(100, Math.round((s.ctxTokens / (s.ctxTokens > 200000 ? 1000000 : 200000)) * 100))
+                : null,
             block: s.block,
             today: s.today,
         }))

--- a/web/public/assets/app.js
+++ b/web/public/assets/app.js
@@ -836,6 +836,14 @@ class Shell {
         // stay live too; paused while the page is hidden. (Requirement: status
         // loaded on startup, not tab-by-tab.)
         this._serverStatusTimer = setInterval(() => { if (!document.hidden) this._pullServerStatus(); }, 4000);
+        // Context % from the transcripts, not from the screen. Claude Code no
+        // longer prints a context reading in its footer, so the scrape that fed
+        // every ctx badge — tabs, fleet bar, manager — finds nothing and the
+        // whole chain reports null. The daemon can measure it exactly instead:
+        // the newest usage record in a session IS its live context. Polled
+        // slowly because it moves once per turn, not once per frame.
+        this._ctxUsageTimer = setInterval(() => { if (!document.hidden) this._pullCtxFromUsage(); }, 15000);
+        setTimeout(() => this._pullCtxFromUsage(), 1500);
         // Self-heal a grid that has fallen behind its container. Refitting is
         // only done when the two actually disagree, so the steady state is two
         // measurements every two seconds and nothing else.
@@ -2059,6 +2067,35 @@ class Shell {
     // slow. A budget turns that into a round-robin: the tab you are looking at
     // is always current, the rest refresh within a few seconds.
     static POLL_BUDGET = 4;
+
+    async _pullCtxFromUsage() {
+        let sessions;
+        try {
+            const r = await fetch('/api/claude-usage', FETCH_INIT);
+            const j = await r.json();
+            sessions = j && j.data && j.data.sessions;
+        } catch (_) { return; }
+        if (!Array.isArray(sessions)) return;
+        // Newest session wins per directory. Tabs that share a cwd cannot be
+        // told apart from here — that is the same binding gap the context canvas
+        // has — so the most recently active one is the honest answer.
+        const byCwd = new Map();
+        for (const s of sessions) {
+            if (!s || !s.cwd || s.ctxPct == null) continue;
+            const prev = byCwd.get(s.cwd);
+            if (!prev || (s.lastTs || 0) > (prev.lastTs || 0)) byCwd.set(s.cwd, s);
+        }
+        if (!byCwd.size) return;   // daemon predates the field; keep scraping
+        for (const [id] of this.tabs) {
+            const cwd = this._tabCwd && this._tabCwd.get(id);
+            const hit = cwd && byCwd.get(cwd);
+            if (!hit) continue;
+            if (this._ctxPct.get(id) === hit.ctxPct) continue;
+            this._ctxPct.set(id, hit.ctxPct);
+            this._updateCtxBar(id, hit.ctxPct);
+            this.bridge.input(INPUT_KIND.CTX_REPORT, { id, pct: hit.ctxPct });
+        }
+    }
 
     _pollCtxLines() {
         const _p0 = PERF.on ? performance.now() : 0;


### PR DESCRIPTION
**Why the per-tab context badges are blank.** Every context reading in the product traces back to one source: the *client* scraping a percentage out of Claude Code's footer and reporting it up with `CTX_REPORT`. The tab badges, the FLEET bar, `sessionManager`'s high-context checks and the usage throttler all consume that one number. Claude Code no longer prints that line, so the scrape finds nothing and the entire chain reports `null`.

**The daemon can measure it exactly instead.** Every transcript record carries the usage of that request, and `input + cache_read + cache_creation + output` **is** the context that request was holding. So the newest record in a session is its live context size — measured, not parsed, and immune to the next change in the TUI. Checked against a live transcript: `2 + 703,438 + 280 + 744 ≈ 704k`.

The context window is inferred rather than configured: a context already past 200k proves a 1M model, and guessing low would report an impossible percentage.

**Rollout is safe in either order.** The client polls `/api/claude-usage` every 15 seconds (context moves once per turn, not once per frame) and applies the value per tab by cwd. When the field is absent — any daemon older than this commit, including the one running now — it does nothing at all and the existing scrape still runs. Confirmed against the live daemon: `ctxPct` absent, client takes the no-op path.

So the badges come back at the next daemon restart, and nothing regresses before it.

Note on the cwd mapping: tabs sharing a directory cannot be told apart from the client, so the most recently active session wins. That is the same tab→session binding gap the context canvas has, and the Stop-hook fix already queued would close both.