### PR TITLE
fix(term): stop one resize from repainting twenty-two agents

### DIFF
--- a/web/public/assets/app.js
+++ b/web/public/assets/app.js
@@ -3380,7 +3380,20 @@ class Shell {
         if (!this._sentSize) this._sentSize = new Map();
         const key = cols + 'x' + rows;
         for (const id of this.order) {
-            if (this._sentSize.get(id) === key) continue;
+            const known = this._sentSize.get(id);
+            if (known === key) continue;
+            // A background tab is told a size EXACTLY ONCE — enough to lift it
+            // off the 120x32 spawn default so its agent wraps sensibly before
+            // you ever look at it. After that it is left alone until you switch
+            // to it, where _activate fits it properly.
+            //
+            // Sending every size change to every tab turned one resize of the
+            // visible terminal into twenty-two SIGWINCHes, and a SIGWINCH makes
+            // Claude repaint its entire screen. Twenty-two full repaints at once,
+            // arriving through a daemon whose event loop is already stalling, is
+            // how the layout ends up shredded — and it got worse with every tab
+            // added, which is exactly the reported shape.
+            if (known && id !== this.activeId) continue;
             this._sentSize.set(id, key);
             this.bridge.input(INPUT_KIND.TERM_RESIZE, { id, cols, rows });
         }


### PR DESCRIPTION
The terminal layout is being shredded, and worse the more tabs there are. That shape is the tell.

`_broadcastSize` sent every size change to **every** tab. So one resize of the visible terminal — a fit, a panel toggle, the 2s fit guard — became **twenty-two `TERM_RESIZE`s**, and a SIGWINCH makes Claude repaint its entire screen. Twenty-two full-screen repaints landing at once, arriving through a daemon whose event loop is already stalling for seconds at a time, interleave into exactly the character-level corruption in the report: stray fragments wedged between words and single characters stranded in the right margin.

It got worse with every tab added, which no per-tab rendering bug would do.

A background tab now gets told a size **exactly once** — all it ever needed, enough to lift it off the `120x32` spawn default so its agent wraps sensibly before you look at it. After that only the **active** tab is resized, and `_activate` already fits a tab properly on switch.

Fleet PTYs are currently uniform at `44x99` and the agent browser is detached, so this is not a width disagreement between clients — it is the volume of resizes, not their value.