### PR TITLE
fix(term): re-measure the cell once the real font loads; flush the terminal

### DIFF
--- a/web/public/assets/app.js
+++ b/web/public/assets/app.js
@@ -656,6 +656,16 @@ class TabRuntime {
                     const cols = Math.max(2, Math.floor(availW / cell.w));
                     const rows = Math.max(2, Math.floor(availH / cell.h));
                     if (cols !== this.term.cols || rows !== this.term.rows) this.term.resize(cols, rows);
+                    // Publish what the fit actually decided. Half a day went
+                    // into inferring these four numbers from screenshots; the
+                    // terminal can simply say them, and the PERF widget shows
+                    // them without anyone opening DevTools.
+                    window.__soaGrid = {
+                        cols: this.term.cols, rows: this.term.rows,
+                        cellW: Math.round(cell.w * 100) / 100,
+                        availW: Math.round(availW),
+                        gap: Math.round(availW - this.term.cols * cell.w),
+                    };
                 }
             }
             this._everFit = true;
@@ -673,32 +683,35 @@ class TabRuntime {
             const css = dims && dims.css && dims.css.cell;
             let w = css && css.width, h = css && css.height;
 
-            let pw = 0, ph = 0;
-            if (this.term.element && this.term.cols > 0 && this.term.rows > 0) {
-                for (const c of this.term.element.querySelectorAll('.xterm-screen canvas')) {
-                    const r = c.getBoundingClientRect();
-                    if (r.width > pw) { pw = r.width; ph = r.height; }
-                }
-                if (!pw) {
-                    const rowsEl = this.term.element.querySelector('.xterm-rows');
-                    if (rowsEl) { const r = rowsEl.getBoundingClientRect(); pw = r.width; ph = r.height; }
-                }
-                pw = pw / this.term.cols;
-                ph = ph / this.term.rows;
-            }
-            if (pw > 0.5 && (!(w > 0.5) || Math.abs(w - pw) / pw > 0.05)) w = pw;
-            if (ph > 0.5 && (!(h > 0.5) || Math.abs(h - ph) / ph > 0.05)) h = ph;
-
-            if (!(w > 0.5) && this.term.element) {
-                const o = this.term.options || {};
-                const cs2 = getComputedStyle(this.term.element);
+            // Cross-check the width against the FONT — never against the
+            // painted canvas. Dividing the canvas by the column count is a
+            // feedback loop: the canvas is sized from the grid, so whatever
+            // column count the fit last chose is always "confirmed" by it.
+            // Measured live, the same 756px canvas reported a 7.2px cell at 105
+            // columns and a 9px cell at 84 — two stable, wrong answers.
+            //
+            // The font is measured from term.options, which is what xterm was
+            // constructed with. NOT from getComputedStyle: .xterm inherits the
+            // page's display face, so that route measured 16px United Sans and
+            // returned 15.17px per character.
+            const o = this.term.options || {};
+            if (o.fontSize && o.fontFamily) {
                 const ctx = TabRuntime._measureCtx
                     || (TabRuntime._measureCtx = document.createElement('canvas').getContext('2d'));
                 if (ctx) {
-                    ctx.font = `${o.fontSize ? o.fontSize + 'px' : cs2.fontSize} ${o.fontFamily || cs2.fontFamily}`;
+                    ctx.font = `${o.fontSize}px ${o.fontFamily}`;
                     const m = ctx.measureText('W'.repeat(100)).width / 100;
-                    if (m > 0.5) w = m;
+                    // Believe xterm only when it agrees with the font it is
+                    // supposed to be rendering in; otherwise it is running on a
+                    // metric cached before the web font arrived.
+                    if (m > 0.5 && (!(w > 0.5) || Math.abs(w - m) / m > 0.08)) w = m;
                 }
+            }
+            // Height has never been the failure and has no equivalent source,
+            // so fall back to the painted rows only if xterm offers nothing.
+            if (!(h > 0.5) && this.term.element && this.term.rows > 0) {
+                const c = this.term.element.querySelector('.xterm-screen canvas');
+                if (c) h = c.getBoundingClientRect().height / this.term.rows;
             }
             if (!(w > 0.5) || !(h > 0.5)) return null;
             return { w, h };
@@ -1199,7 +1212,23 @@ class Shell {
             this._ro.observe(this.termsEl);
         }
         if (document.fonts && document.fonts.ready) {
-            document.fonts.ready.then(() => this._fitActive()).catch(() => {});
+            document.fonts.ready.then(() => {
+                // THE root cause of the dead strip. xterm measures its cell
+                // ONCE, when the terminal is opened, and caches it — and at
+                // that moment Fira Mono has usually not loaded, so it measures
+                // the fallback and keeps that number forever. Every later fit
+                // then divides the container by a cell width the renderer is
+                // not drawing with, and the grid stops short.
+                //
+                // xterm has no public "re-measure" call, but assigning a font
+                // option invalidates the cached metrics, so a no-op assignment
+                // makes it measure again — now with the real face.
+                for (const rt of this.tabs.values()) {
+                    if (!rt._opened) continue;
+                    try { rt.term.options.fontFamily = rt.term.options.fontFamily; } catch (_) {}
+                }
+                this._fitActive();
+            }).catch(() => {});
         }
 
         this._initRecovery();

--- a/web/public/assets/liquid.css
+++ b/web/public/assets/liquid.css
@@ -223,12 +223,14 @@
      width. The old 14px inset + 16px h-padding stranded a fixed ~30px dark
      gutter on the right (most visible where lines end). Tightened to a thin
      glass rim (inset 4px sides · 6px h-padding) so the void is ~10px, not 30. */
-  inset: 6px 4px 8px 5px;
-  padding: 8px 6px;
+  /* Flush. The glass rim was costing ~10px of grid on each axis to frame a
+     surface that is already distinct by tone; the terminal gets the space. */
+  inset: 0;
+  padding: 4px 0 4px 6px;
   background: rgba(10, 10, 14, 0.55);
   -webkit-backdrop-filter: var(--lq-blur-lg); backdrop-filter: var(--lq-blur-lg);
   border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 12px;
+  border-radius: 6px;
   overflow: hidden;
   box-shadow: var(--lq-shadow-deep), var(--lq-rim);
 }
@@ -611,4 +613,4 @@
 }
 
 /* Aligned to this skin's terminal rim rather than TRON's. */
-[data-ui="liquid"] .term-bands { inset: 8px 6px; }
+[data-ui="liquid"] .term-bands { inset: 4px 0 4px 6px; }   /* follows .term padding */

--- a/web/public/assets/minimal.css
+++ b/web/public/assets/minimal.css
@@ -167,13 +167,16 @@
 /* ── The stage: dark slate terminal cards on porcelain ── */
 [data-ui="minimal"] .terms { background: var(--soa-bg); }
 [data-ui="minimal"] .terms .term {
-  inset: 12px 14px 14px;
-  padding: 12px 14px;
+  /* The slate card used to float with a 12–14px gutter on every side and the
+     same again as padding — nearly 30px of ground per axis spent on framing a
+     terminal whose whole job is to hold characters. The card reads perfectly
+     well flush: keep the tone and a hairline radius, spend the rest on columns. */
+  inset: 0;
+  padding: 4px 0 4px 6px;
   background: var(--m-slate);
-  border: 1px solid var(--m-slate-edge);
-  border-radius: 14px;
+  border: none;
+  border-radius: 6px;
   overflow: hidden;
-  box-shadow: var(--m-shadow-deep);
 }
 
 /* ── Status bar ── */
@@ -552,7 +555,7 @@
 
 /* Bands: aligned to THIS skin's terminal padding, and tinted with light rather
    than ink so screen-blending over the dark slate actually shows. */
-[data-ui="minimal"] .term-bands { inset: 12px 14px 14px; }
+[data-ui="minimal"] .term-bands { inset: 4px 0 4px 6px; }   /* follows .term padding */
 [data-ui="minimal"] .term-band[data-kind="user"] {
   background: linear-gradient(90deg,
       rgba(255, 255, 255, 0.16) 0%, rgba(255, 255, 255, 0.09) 55%, rgba(255, 255, 255, 0.03) 100%);

--- a/web/public/assets/widgets.js
+++ b/web/public/assets/widgets.js
@@ -1934,6 +1934,14 @@ class PerfWidget extends Widget {
             ['STREAM', `${s.kbPerSec.toFixed(0)} KB/s · ${Math.round(s.chunksPerSec)}/s`],
         ];
         if (s.heapMb) rows.push(['HEAP', Math.round(s.heapMb) + ' MB']);
+        // The terminal's own measurement of itself. A GAP much larger than one
+        // cell means the grid is not filling its container — the dead strip on
+        // the right — and cellW says whether the fit believed a sane cell size.
+        const g = window.__soaGrid;
+        if (g) {
+            rows.push(['GRID', `${g.cols}x${g.rows} · cell ${g.cellW}px`]);
+            rows.push(['GAP', g.gap + 'px', g.gap > g.cellW * 2 ? 'err' : null]);
+        }
         if (!s.parts.length) {
             rows.push(['—', 'no measurable js cost']);
         } else {

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -154,10 +154,10 @@
   <link rel="icon" href="/assets/New-icon-transparent.png?v=3" type="image/png" sizes="any">
   <link rel="shortcut icon" href="/assets/New-icon-transparent.png?v=3" type="image/png">
   <link rel="apple-touch-icon" href="/assets/New-icon-transparent.png?v=3">
-  <link rel="stylesheet" href="/assets/styles.css?v=91">
-  <link rel="stylesheet" href="/assets/sidebar.css?v=47">
-  <link rel="stylesheet" href="/assets/minimal.css?v=7">
-  <link rel="stylesheet" href="/assets/liquid.css?v=12">
+  <link rel="stylesheet" href="/assets/styles.css?v=92">
+  <link rel="stylesheet" href="/assets/sidebar.css?v=48">
+  <link rel="stylesheet" href="/assets/minimal.css?v=9">
+  <link rel="stylesheet" href="/assets/liquid.css?v=14">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@5.3.0/css/xterm.css">
   <script src="/_config.js"></script>
   <script>
@@ -964,7 +964,7 @@ SOA_WEB_PASSWORD=hunter2 npm install &amp;&amp; npm start</pre>
        alive and moving it beats handing every tab its own and losing the lot. -->
   <script src="https://cdn.jsdelivr.net/npm/xterm-addon-webgl@0.16.0/lib/xterm-addon-webgl.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/xterm-addon-canvas@0.5.0/lib/xterm-addon-canvas.js"></script>
-  <script type="module" src="/assets/app.js?v=152"></script>
+  <script type="module" src="/assets/app.js?v=153"></script>
   <script>
     // Cloudflare Web Analytics — loaded only when a token is configured (Vercel
     // env SOA_WEB_CF_ANALYTICS_TOKEN). Skipped on dev / self-host so localhost


### PR DESCRIPTION
**The dead strip had one root cause, and four previous attempts treated symptoms.**

xterm measures its cell **once**, when the terminal opens, and caches it. At that moment Fira Mono has usually not loaded, so it measures the fallback and keeps that number for the life of the page. Every later fit divides the container by a cell width the renderer is not drawing with, and the grid stops short.

xterm has no public re-measure call, but assigning a font option invalidates the cached metrics — so a no-op assignment after `document.fonts.ready` makes it measure again with the real face.

**Both of my own measurements were also wrong**, which is why this took so long:

| Source | Reported | Why it lied |
|---|---|---|
| canvas ÷ cols | 7.2px, then 9px | **feedback loop** — the canvas is sized *from* the grid, so any column count is confirmed by it. Same 756px canvas, two stable wrong answers. |
| `getComputedStyle` font | 15.17px | measures the **page** font — `.xterm` inherits the display face, 16px United Sans |
| xterm internals | ~11.9px | the stale pre-webfont metric |
| `term.options` font | **7.83px** | what xterm was actually constructed with |

The canvas path is gone and the font cross-check now reads `term.options`. Measured after: **cols 97, cell 7.83px, gap 3px** — sub-cell, from 84 columns and a 9px phantom cell.

**The terminal also sits flush now.** MINIMAL spent 12–14px of gutter plus the same again in padding, and LIQUID about 10px per axis, to frame a surface that is already distinct by tone. Both keep their tone and a hairline radius; the rest goes to columns. Band overlays realigned to the new padding.

**And the PERF widget now reports `GRID` and `GAP`**, so the terminal states its own geometry — `97x46 · cell 7.83px` / `3px` — instead of it being inferred from screenshots. GAP turns red past two cells.