### PR TITLE
fix(term): render at the PTY's grid, not the widest viewer's

### DIFF
--- a/SESSION-CONTEXT.md
+++ b/SESSION-CONTEXT.md
@@ -7,6 +7,169 @@ time; treat them as a starting point to re-check, not gospel.
 
 ---
 
+## 2026-09-11 · Claude · the left-hand corruption, and batching the fleet's output
+
+Two separate problems, one session. The first was the reported bug; the second
+was the open question next to it.
+
+### The corruption: the PTY and the emulator were different sizes
+
+Measured on the live machine, not inferred: `__soaGrid` said the desktop's xterm
+was **115x53**, and `stty -f /dev/ttys003 size` said the PTY behind that same tab
+was **134x61**. The agent draws 134-column lines, xterm has 115 columns, so every
+long line soft-wraps and the ~19-character tail lands in the LEFT-HAND columns of
+the row below — on top of the text already there. That is the "drifts to the left
+and obscures part of the left texts" the user reported, and the ragged left-edge
+fragments in their screenshot are those tails.
+
+**Root cause: the server resized the shared PTY to the MAX size any live client
+wanted.** Written to stop a narrow phone clipping a wide desktop. But a terminal
+emulator cannot show more columns than it has: the wide client is fine and every
+narrower client gets corruption instead of a gutter. Two things made it stick:
+
+- sizes were recorded **per socket per tab**, and recomputed only when a resize
+  came IN. A window that had since closed went on pinning every PTY to its width
+  forever — nothing ever recomputed on disconnect.
+- the client only reports on CHANGE (xterm's `onResize` fires on change, and
+  `_broadcastSize` tells a background tab its size exactly once), so switching to
+  a stale tab never re-asserted anything.
+
+The fix is the one every multiplexer already reached: **the smallest attached
+viewer defines the grid** (`server/src/termGeometry.js`), a viewport belongs to
+the SOCKET rather than to a tab (one terminal area on screen describes them all,
+including tabs never visited), and geometry is recomputed at the three moments
+the answer can change — an inbound resize, a tab becoming active, a socket
+closing. The daemon then ANNOUNCES the result as `MSG.TERM_SIZE`, and the client
+renders at that grid rather than at its own measurement.
+
+The desktop now separates two numbers that used to be one: `_desired` (what this
+window measured — reported up as a request) and `_authGrid` (what the PTY is —
+what we draw at). Echoing an adopted grid back would ratchet it down to the
+minimum a little further every round, so `_suppressReport` blocks that path. The
+mobile client already worked this way; it only needed the new frame wired in.
+
+Verified end-to-end against a scratch daemon on :7412 with real PTYs: two viewers
+at 134x61 and 115x53 -> the PTY takes 115x53, **`stty size` inside the shell
+agrees**, and when the narrow viewer disconnects the grid reopens to 134x61.
+
+Note the cost this trades away: a viewer wider than the grid now has unused
+columns on the right while a smaller one is attached. That is the "black void on
+the right" the MAX rule was written to avoid. It is the right trade — a gutter is
+cosmetic and self-explanatory, corruption is neither — and only the desktop
+client declares a viewport at all, so attaching a phone never narrows anything.
+
+### Responsiveness: the message count, not the bytes
+
+Every chunk from every tab was its own WebSocket frame: a `JSON.stringify` on the
+server, a `message` event and a `JSON.parse` in the browser, then the detector
+pass. That is a fixed per-message cost paid once per chunk per tab, and it scales
+with the number of running agents even though 21 of 22 terminals are not painted.
+
+`server/src/termBatch.js` coalesces output into ONE `TERM_BATCH` frame per tick.
+Latency is spent only where it shows: the tab on screen flushes on a 12ms window
+(less than the rAF the client already coalesces xterm writes to), everything else
+on 100ms, because nothing renders a background tab's bytes until you switch to
+it. Opt-in per socket via `INPUT_KIND.CLIENT_CAPS`, so share viewers and any tab
+still running the old bundle keep the original one-frame-per-chunk wire.
+
+Measured on the scratch daemon, same shells, same bytes:
+
+| tabs | frames/s before | after | |
+|---|---|---|---|
+| 12 | 51.1 | 10.1 | 5.0x fewer |
+| 22 | 66.8 | 7.3 | **9.2x fewer** |
+
+The ratio grows with tab count, which is the shape of the original complaint.
+
+### Still open
+
+- The desktop still runs its own `_detectAgentFromStream` per chunk per tab
+  (`sb.recent += data` on every chunk, ~2 KB of garbage per tab) while the
+  server's `sessionManager.feed` already derives the same status. One of the two
+  is redundant.
+- The per-chunk `audio.play('stdout', 'tab'+id)` fires for background tabs too.
+- `.terms .xterm-screen { width: 100% !important }` makes the screen element
+  wider than the canvas it contains (1052.93 vs 1045 measured). Harmless for
+  paint; left alone rather than risk a selection/hit-testing regression.
+
+---
+
+## 2026-09-10 · Codex · terminal streaming follow-up
+
+User confirmed the corruption happens **inside SoA only**, while output is
+streaming. Codex's braille sparkle animation overwrites prompt/status text in
+the supplied example. The working tree contains a tested follow-up patch;
+it has not been committed, published, or loaded by restarting the live daemon.
+
+### Corrections to the previous diagnosis
+
+- **The same-value font assignment in #54 does nothing.** The exact shipped
+  xterm 5.3.0 bundle emitted zero option events for `fontFamily = fontFamily`.
+  Its OptionsService explicitly deduplicates equal values. The patch changes
+  the family to an equivalent whitespace-suffixed value and restores it, which
+  emits real option events. Hidden terminals defer this until visible. Both
+  `document.fonts.ready` and later `loadingdone` events invalidate metrics.
+- Canvas `measureText` measures a glyph, not the renderer's cell (which includes
+  spacing and device-pixel rounding). Fit now uses the renderer's CSS cell size
+  after invalidation; missing metrics keep replay queued instead of declaring
+  a successful fit at the default grid.
+- **Resize A → B → A within the debounce window left the PTY at B.** The
+  equality shortcut returned before cancelling pending B. Cancellation now
+  happens before deduplication, so a settled browser at A cannot send stale B.
+
+### Streaming fixes in the working tree
+
+- Deferred background snapshots could arrive AFTER live output, and include
+  those same live bytes again. Reproduced `new → old → new`. New
+  `server/src/terminalReplay.js` gates live terminal data per joining socket/tab
+  until its snapshot is enqueued. Existing sockets and heartbeats keep flowing.
+- Desktop HELLO/replay now replace old queues and terminal state on reconnect.
+  The reset is queued as CAN + RIS with replay, preserving ordering with writes
+  already accepted by xterm's asynchronous parser.
+- Oversized single frames now respect the hidden replay cap; actual eviction
+  is tracked separately from retained length, and truncated prefixes are
+  cancelled and advanced to an ESC/newline boundary before parsing resumes.
+
+### Validation and deployment state
+
+- **187/187 `npm test` tests pass**, including 10 client regressions and six
+  server replay cases. Client tests extract the actual TabRuntime class.
+- Additional offline checks using the real xterm 5.3.0 bundle verified font
+  option events and reconnect reset ordering, including a pending partial ANSI
+  sequence. Syntax checks and `git diff --check` passed.
+- `scripts/smoke-ws.js` passed against a separate daemon on port 7411 with state
+  under `/private/tmp/soa-terminal-smoke-state`, using `/bin/sh` and no tunnel
+  or agent auto-resume. No live fleet was exercised by that check.
+- Live pid 94615 was still the daemon started **Sep 7 15:03:45**. A one-off
+  loopback ping was <1ms; that does not rule out its documented periodic stalls.
+  Server changes still require a deliberate restart that respawns live shells.
+- Desktop entry asset bumped to `app.js?v=154`. Chrome was viewing `s0a.app`
+  with a localhost backend, so publishing public static assets is distinct
+  from serving this checkout at `http://127.0.0.1:4010`.
+
+### Remaining limitations to check if corruption persists
+
+- Multiple desktop viewers can still disagree with the shared PTY dimensions.
+  Independent maxima combine 100×50 and 160×30 into 160×50; desktop xterm sizes
+  itself locally and does not implement the claimed larger-grid scroll/scale.
+  Disconnect also does not recompute the size. A full repair needs separate
+  requested viewport and authoritative PTY geometry, with replay dimensions.
+  The mobile client currently sends no TERM_RESIZE, so two devices alone is not
+  proof that this is the user's trigger.
+- Raw capped ANSI replay cannot reconstruct all cursor/mode state lost from
+  an earlier prefix, especially after resizing. A screen snapshot would be
+  needed for exact restoration. Mobile/share reconnect behavior is unchanged.
+- macOS cwd polling still uses synchronous per-tab `lsof`; its live stall cost
+  was not measured in this follow-up.
+- Codex 0.154.0 supports `--approve-for-me`, documented `tui.animations=false`,
+  and locally verified boolean `tui.whimsy=false`. The binary contains a
+  composer `sparkle.rs`; whimsy disabling those exact particles is an inference.
+  A scoped next-launch workaround is
+  `codex resume --last --approve-for-me -c tui.animations=false -c tui.whimsy=false`.
+  No Codex settings were changed.
+
+---
+
 ## 2026-09-07 → 2026-09-09 · tab #1 `app` · session `6321e8b7`
 
 Continuation of the session below. Two threads: a long hunt for terminal lag

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -43,6 +43,9 @@ const consoleLogs      = require('./consoleLogs');
 const { MSG, INPUT_KIND, frame, parse } = require('./protocol');
 const { SessionStore } = require('./sessionStore');
 const { TabManager }   = require('./tabManager');
+const { streamBackgroundReplay } = require('./terminalReplay');
+const { TermBatcher } = require('./termBatch');
+const termGeometry = require('./termGeometry');
 const auth             = require('./auth');
 const sysinfo          = require('./sysinfo');
 const claudeUsage      = require('./claudeUsage');
@@ -703,6 +706,32 @@ function _broadcastDeviceCount(session, excludeWs) {
     }
 }
 
+// Bring ONE tab's PTY to the grid every attached viewer can actually render,
+// and tell the clients what that grid is. See termGeometry.js for why the
+// smallest viewer wins: a PTY wider than the emulator showing it does not get
+// clipped, it gets soft-wrapped, and the wrapped tail lands on top of the next
+// row's left-hand columns.
+//
+// Called from the three places the answer can change: an inbound resize, a tab
+// becoming active (which is when a background tab's stale size finally
+// matters), and a socket closing (which is how a window that no longer exists
+// used to go on pinning every PTY to its width).
+function syncTabGeometry(session, tabId) {
+    const mgr = session && session.tabMgr;
+    const tab = mgr && mgr.get(tabId);
+    if (!tab) return null;
+    const size = termGeometry.agreedSize(termGeometry.liveViewports(session.sockets));
+    if (!size) return null;
+    if (tab.cols === size.cols && tab.rows === size.rows) return size;
+    dbg('geometry', 'tab=' + tabId, tab.cols + 'x' + tab.rows, '→', size.cols + 'x' + size.rows,
+        '(min across ' + session.sockets.size + ' socket(s))');
+    tab.resize(size.cols, size.rows);
+    const f = frame(MSG.TERM_SIZE, { id: tabId, cols: size.cols, rows: size.rows });
+    session.send(f);
+    if (SHARE_ENABLED && session.shareViewers.size) session.sendToShareViewers(tabId, f);
+    return size;
+}
+
 function onWsConnect(ws, session, req) {
     ws._connectedAt = Date.now();
     ws._userAgent = (req && req.headers && req.headers['user-agent']) || '';
@@ -718,15 +747,27 @@ function onWsConnect(ws, session, req) {
     ws.on('pong', () => { ws.isAlive = true; });
 
     if (!session.tabs) session.tabs = [];
+    if (!session._termBatcher) {
+        session._termBatcher = new TermBatcher({
+            sockets: () => session.sockets,
+            activeTab: () => session.activeTab,
+            onShare: SHARE_ENABLED
+                ? (tabId, f) => { if (session.shareViewers.size) session.sendToShareViewers(tabId, f); }
+                : null,
+        });
+    }
     if (!session.tabMgr) {
         session.tabMgr = new TabManager({
             onData: (tabId, data) => {
                 agg('term-out', 'session=' + session.id.slice(0, 8) + ' tab=' + tabId, data.length, '→ ' + session.sockets.size + ' socket(s)');
-                const _tf = frame(MSG.TERM_DATA, { id: tabId, data });
-                session.send(_tf);
-                if (SHARE_ENABLED && session.shareViewers.size) session.sendToShareViewers(tabId, _tf);
-                // Feed the always-on supervisor so it tracks status + context
-                // for every tab regardless of which client is watching.
+                // Queued, not sent: many tabs producing at once collapse into
+                // one frame per tick instead of one frame per chunk per tab.
+                // See termBatch.js — the client's cost stops scaling with the
+                // number of running agents.
+                session._termBatcher.push(tabId, data);
+                // The supervisor is in-process and cheap, so it still sees
+                // every chunk the instant it lands — batching is a wire
+                // concern, not a bookkeeping one.
                 try { sessionManager.ensure(session).feed(tabId, data); } catch (_) {}
             },
             onTabsChange: list => {
@@ -917,6 +958,10 @@ function onWsConnect(ws, session, req) {
     ws.on('close', () => {
         try { agentBrowser.unsubscribeAll(ws); } catch (_) {}
         session.detachSocket(ws);
+        // A window that has gone away must stop constraining the grid. Only the
+        // tab on screen is re-sized now; the rest pick the new size up when they
+        // are next activated, so closing a laptop lid is not 22 SIGWINCHes.
+        try { if (ws._viewport && session.activeTab) syncTabGeometry(session, session.activeTab); } catch (_) {}
         _broadcastDeviceCount(session);
     });
     ws.on('error', () => { /* close handler will fire too */ });
@@ -990,33 +1035,6 @@ if (SHARE_ENABLED) {
     if (_shareSweep.unref) _shareSweep.unref();
 }
 
-// Stream each background tab's scrollback as its own REPLAY frame, one at a
-// time, yielding to the event loop between sends so WebSocket control frames
-// (ping/pong) and the client's keepalive interleave instead of being stuck
-// behind one multi-MB HELLO. Honours backpressure: if the socket's send buffer
-// is already deep, wait for it to drain before queuing more. Best-effort —
-// bails the moment the socket is no longer OPEN (closed, or reconnected with a
-// fresh ws that will get its own stream).
-const REPLAY_HIGH_WATER = 512 * 1024; // bytes buffered before we pause to drain
-function streamBackgroundReplay(ws, session, tabList, activeId) {
-    const ids = tabList.map(t => t.id).filter(id => id !== activeId);
-    if (!ids.length) return;
-    let i = 0;
-    const sendNext = () => {
-        if (!ws || ws.readyState !== 1) return; // socket gone / reconnected
-        if (i >= ids.length) return;
-        if (ws.bufferedAmount > REPLAY_HIGH_WATER) { setTimeout(sendNext, 50); return; }
-        const id = ids[i++];
-        let data = '';
-        try { data = session.tabMgr.scrollback(id); } catch (_) {}
-        if (data && data.length) {
-            try { ws.send(frame(MSG.REPLAY, { id, data })); } catch (_) { return; }
-        }
-        setImmediate(sendNext);
-    };
-    setImmediate(sendNext);
-}
-
 // Auto-resume Claude in tabs restored after a daemon restart. The respawned
 // shells are fresh (dead), so each tab's conversation is lost unless we resume
 // it. For every restored tab whose cwd has a recent Claude transcript, type
@@ -1051,7 +1069,7 @@ function scheduleAutoResume(restoredTabs, tabMgr) {
 function handleInput(session, d, ws) {
     const mgr = session.tabMgr;
     if (d.kind === INPUT_KIND.TERM_RESIZE) {
-        dbg('input', 'TERM_RESIZE from device — tab=' + d.id, d.cols + 'x' + d.rows, '(shared pty resizes to MAX across live clients)');
+        dbg('input', 'TERM_RESIZE from device — tab=' + d.id, d.cols + 'x' + d.rows, '(shared pty takes the MIN across live viewers)');
     } else if (d.kind === INPUT_KIND.TERM_KEYS) {
         dbg('input', 'TERM_KEYS tab=' + d.id, JSON.stringify((d.text || '').slice(0, 16)));
     } else if (d.kind) {
@@ -1079,6 +1097,11 @@ function handleInput(session, d, ws) {
         case INPUT_KIND.SWITCH_TAB: {
             if (mgr.get(d.id) && session.activeTab !== d.id) {
                 session.activeTab = d.id;
+                // The moment a tab goes on screen is the moment its geometry
+                // has to be right. Doing it here rather than for all 22 tabs on
+                // every window resize is deliberate: a PTY resize is a SIGWINCH
+                // and a SIGWINCH makes the agent repaint its entire TUI.
+                syncTabGeometry(session, d.id);
                 session.send(frame(MSG.SNAPSHOT, { tabs: mgr.list(), activeId: d.id, connectedDevices: session.sockets.size }));
             }
             break;
@@ -1116,7 +1139,7 @@ function handleInput(session, d, ws) {
             const t = mgr.restore({ id: d.id != null ? +d.id : null, cols: d.cols, rows: d.rows });
             if (t) {
                 session.activeTab = t.id;
-                session.send(frame(MSG.TERM_DATA, { id: t.id, data: mgr.scrollback(t.id) }));
+                session.sendTerminalData(t.id, frame(MSG.TERM_DATA, { id: t.id, data: mgr.scrollback(t.id) }));
                 session.send(frame(MSG.SNAPSHOT, {
                     tabs: mgr.list(),
                     activeId: t.id,
@@ -1144,29 +1167,21 @@ function handleInput(session, d, ws) {
             break;
         }
         case INPUT_KIND.TERM_RESIZE: {
-            const tab = mgr.get(d.id);
-            if (!tab) break;
-            const cols = Math.max(2, d.cols | 0);
-            const rows = Math.max(2, d.rows | 0);
-            // Remember THIS client's desired size for this tab.
-            if (ws) {
-                if (!ws._tabSizes) ws._tabSizes = new Map();
-                ws._tabSizes.set(d.id, { cols, rows });
-            }
-            // Resize the SHARED pty to the LARGEST size any live client wants
-            // for this tab — a narrow phone can then never clip the wide
-            // desktop (the "black void on the right when a mobile is attached,
-            // and it stays while the desktop is idle" bug). Smaller clients
-            // just scroll/scale; the widest surface stays whole.
-            let maxCols = cols, maxRows = rows;
-            for (const sock of session.sockets) {
-                if (!sock || sock.readyState !== 1 || !sock._tabSizes) continue;
-                const sz = sock._tabSizes.get(d.id);
-                if (!sz) continue;
-                if (sz.cols > maxCols) maxCols = sz.cols;
-                if (sz.rows > maxRows) maxRows = sz.rows;
-            }
-            tab.resize(maxCols, maxRows);
+            if (!mgr.get(d.id)) break;
+            // The viewport belongs to the SOCKET, not the tab: every tab in a
+            // session shares one terminal area on screen, so one measurement
+            // describes all of them — including tabs this client has never
+            // opened, which is how a background agent used to sit at the 120x32
+            // spawn size until you happened to visit it.
+            const vp = termGeometry.normalizeViewport(d.cols, d.rows);
+            if (ws && vp) ws._viewport = vp;
+            syncTabGeometry(session, d.id);
+            break;
+        }
+        case INPUT_KIND.CLIENT_CAPS: {
+            // What this socket can decode. Absent = the original one-frame-per
+            // chunk wire, which every client understands.
+            if (ws) ws._caps = Object.assign({}, ws._caps, (d.caps && typeof d.caps === 'object') ? d.caps : {});
             break;
         }
         case INPUT_KIND.HOTKEY: {

--- a/server/src/protocol.js
+++ b/server/src/protocol.js
@@ -17,6 +17,8 @@ const MSG = Object.freeze({
     REPLAY:     'replay',
     SNAPSHOT:   'snapshot',
     TERM_DATA:  'term-data',
+    TERM_BATCH: 'term-batch', // {items:[{id,data}]} — many tabs' output coalesced into ONE frame
+    TERM_SIZE:  'term-size',  // {id,cols,rows} — the AUTHORITATIVE pty geometry for a tab
     TERM_EXIT:  'term-exit',
     NOTICE:     'notice',
     PONG:       'pong',
@@ -51,6 +53,7 @@ const INPUT_KIND = Object.freeze({
     BROWSER_UNSUBSCRIBE: 'browser-unsubscribe',
     BROWSER_CLICK:       'browser-click',
     WINDOW_CONTROL:      'window-control',
+    CLIENT_CAPS:         'client-caps',   // {caps:{termBatch:true}} — what this socket can decode
 });
 
 function frame(type, data, id) {

--- a/server/src/sessionStore.js
+++ b/server/src/sessionStore.js
@@ -53,6 +53,19 @@ class Session {
         return delivered > 0;
     }
 
+    // A new socket gets each background tab's snapshot before its live bytes.
+    // Pending output is already in the tab's bounded scrollback, which replay
+    // reads when it sends; queuing those frames here would duplicate the tail.
+    sendTerminalData(tabId, frameStr) {
+        let delivered = 0;
+        for (const ws of this.sockets) {
+            if (!ws || ws.readyState !== 1 /* OPEN */) continue;
+            if (ws._pendingReplayTabs && ws._pendingReplayTabs.has(tabId)) continue;
+            try { ws.send(frameStr); delivered++; } catch (_) { /* drop */ }
+        }
+        return delivered > 0;
+    }
+
     addShareViewer(tabId, ws) {
         const key = Number(tabId);
         if (!this.shareViewers.has(key)) this.shareViewers.set(key, new Set());
@@ -110,6 +123,7 @@ class SessionStore {
         if (session._cwdInterval) clearInterval(session._cwdInterval);
         if (session._managerInterval) clearInterval(session._managerInterval);
         if (session._scrollbackInterval) clearInterval(session._scrollbackInterval);
+        if (session._termBatcher) { try { session._termBatcher.destroy(); } catch (_) {} }
         // The SessionManager owns its own 15s schedule timer (and parked watch
         // waiters) — tear it down too, else it fires forever and pins this session.
         if (session._manager && typeof session._manager.destroy === 'function') {

--- a/server/src/termBatch.js
+++ b/server/src/termBatch.js
@@ -1,0 +1,166 @@
+/**
+ * termBatch — one WebSocket frame per tick, not one per PTY read.
+ *
+ * Every chunk a tab produced used to become its own frame: JSON.stringify on
+ * the server, a `message` event and a JSON.parse in the browser, then the
+ * detector pass and the replay append. That is a fixed per-message cost paid
+ * once per chunk per tab, and node-pty emits small chunks very often — so the
+ * work the client does scales with (number of agents x their chunk rate) even
+ * though 21 of 22 terminals are not on screen and will never be painted.
+ *
+ * The bytes were never the problem; the message count was. So hold whatever
+ * arrives during one short window and send it as a single TERM_BATCH frame
+ * carrying every tab's slice. The client then pays ONE parse for the whole
+ * fleet's output per tick instead of one per chunk, and the cost stops scaling
+ * with the number of running agents.
+ *
+ * JSON escaping is the tax that rides along with it: terminal output is mostly
+ * escape sequences, and every ESC costs six characters on the wire. Batching
+ * does not remove that, but it stops re-paying the envelope, the send, and the
+ * parse for each fragment.
+ *
+ * Latency is spent where it is visible and saved where it is not. The tab on
+ * screen flushes on a one-frame window (12ms, SOA_TERM_BATCH_MS) — less than
+ * the requestAnimationFrame the client already coalesces its xterm writes to.
+ * Every other tab is not being painted at all: nothing renders its bytes until
+ * you switch to it, so it waits for a much longer window (100ms,
+ * SOA_TERM_BATCH_BG_MS) and collapses far harder. With one agent on screen and
+ * twenty-one behind it, almost all of the traffic is on the slow path.
+ *
+ * Set either to 0 to flush on the next tick instead, which still merges
+ * everything node delivered in the same poll phase.
+ *
+ * Compatibility is per socket, never global: a client opts in by sending
+ * INPUT_KIND.CLIENT_CAPS with `{termBatch:true}`. Anything that has not opted
+ * in — a tab still running the previous bundle, the read-only share viewers —
+ * keeps receiving one TERM_DATA frame per chunk exactly as before.
+ */
+
+const { MSG, frame } = require('./protocol');
+
+const envMs = (name, fallback) => {
+    const raw = parseInt(process.env[name] || '', 10);
+    return Number.isFinite(raw) && raw >= 0 ? Math.min(raw, 2000) : fallback;
+};
+const BATCH_MS = envMs('SOA_TERM_BATCH_MS', 12);
+const BATCH_BG_MS = envMs('SOA_TERM_BATCH_BG_MS', 100);
+
+class TermBatcher {
+    /**
+     * @param {object} opts
+     * @param {() => Iterable} opts.sockets                             live session sockets
+     * @param {(tabId:number, frameStr:string) => void} [opts.onShare]  read-only viewers
+     * @param {() => number} [opts.activeTab]   the tab currently on screen
+     * @param {number} [opts.delayMs]           window for the tab on screen
+     * @param {number} [opts.bgDelayMs]         window for everything else
+     * @param {() => number} [opts.now]
+     */
+    constructor({ sockets, onShare, activeTab, delayMs = BATCH_MS, bgDelayMs = BATCH_BG_MS, now }) {
+        this._sockets = sockets;
+        this._onShare = onShare || null;
+        this._activeTab = activeTab || (() => null);
+        this._delayMs = delayMs;
+        this._bgDelayMs = Math.max(bgDelayMs, delayMs);
+        this._now = now || (() => Date.now());
+        this._pending = new Map();   // tabId -> string[]
+        this._timer = null;
+        this._immediate = null;
+        this._lastBgFlush = 0;
+    }
+
+    /** Queue one tab's output. Ordering within a tab is preserved. */
+    push(tabId, data) {
+        if (!data) return;
+        const q = this._pending.get(tabId);
+        if (q) q.push(data);
+        else this._pending.set(tabId, [data]);
+        this._arm(tabId === this._activeTab() ? this._delayMs : this._bgDelayMs);
+    }
+
+    // Wake no later than the soonest thing waiting needs. A background chunk
+    // arriving behind an active one must not push the active one's flush out.
+    _arm(delayMs) {
+        if (this._immediate) return;
+        if (this._timer) {
+            if (this._timerAt <= this._now() + delayMs) return;
+            clearTimeout(this._timer);
+            this._timer = null;
+        }
+        if (delayMs > 0) {
+            this._timerAt = this._now() + delayMs;
+            this._timer = setTimeout(() => this.flush(), delayMs);
+            if (this._timer.unref) this._timer.unref();
+        } else {
+            this._immediate = setImmediate(() => this.flush());
+        }
+    }
+
+    /**
+     * Send what is due. The tab on screen goes every tick; the rest ride along
+     * only once their own, much longer window has elapsed — nothing is painting
+     * them, so holding them is free, and it is where nearly all of the traffic
+     * is when one agent is visible and twenty-one are not.
+     */
+    flush() {
+        if (this._timer) { clearTimeout(this._timer); this._timer = null; }
+        if (this._immediate) { clearImmediate(this._immediate); this._immediate = null; }
+        if (!this._pending.size) return;
+
+        const now = this._now();
+        const active = this._activeTab();
+        const bgDue = this._bgDelayMs <= this._delayMs || (now - this._lastBgFlush) >= this._bgDelayMs;
+        if (bgDue) this._lastBgFlush = now;
+
+        const items = [];
+        for (const [id, chunks] of this._pending) {
+            if (!bgDue && id !== active) continue;
+            items.push({ id, data: chunks.length === 1 ? chunks[0] : chunks.join('') });
+            this._pending.delete(id);
+        }
+        if (this._pending.size) this._arm(this._bgDelayMs - (now - this._lastBgFlush));
+        if (!items.length) return;
+
+        // Each wire form is built at most once, and only if somebody needs it.
+        let batchAll = null;
+        const perItem = new Map();
+        const itemFrame = (it) => {
+            let f = perItem.get(it);
+            if (!f) { f = frame(MSG.TERM_DATA, { id: it.id, data: it.data }); perItem.set(it, f); }
+            return f;
+        };
+
+        for (const ws of this._sockets() || []) {
+            if (!ws || ws.readyState !== 1 /* OPEN */) continue;
+            // A socket that has been promised a replay for a tab must not see
+            // that tab's live bytes first — the replay carries them already.
+            const held = ws._pendingReplayTabs;
+            const mine = (held && held.size) ? items.filter(it => !held.has(it.id)) : items;
+            if (!mine.length) continue;
+            try {
+                if (ws._caps && ws._caps.termBatch) {
+                    const payload = mine === items
+                        ? (batchAll || (batchAll = frame(MSG.TERM_BATCH, { items })))
+                        : frame(MSG.TERM_BATCH, { items: mine });
+                    ws.send(payload);
+                } else {
+                    for (const it of mine) ws.send(itemFrame(it));
+                }
+            } catch (_) { /* drop — the close handler cleans up */ }
+        }
+
+        if (this._onShare) {
+            for (const it of items) {
+                try { this._onShare(it.id, itemFrame(it)); } catch (_) {}
+            }
+        }
+    }
+
+    /** Flush everything, background included, and stop. */
+    destroy() {
+        this._lastBgFlush = 0;
+        try { this.flush(); } catch (_) {}
+        this._pending.clear();
+    }
+}
+
+module.exports = { TermBatcher, BATCH_MS };

--- a/server/src/termGeometry.js
+++ b/server/src/termGeometry.js
@@ -1,0 +1,80 @@
+/**
+ * termGeometry — one shared PTY, several viewers, ONE honest grid.
+ *
+ * A tab's PTY has exactly one size, but any number of browsers can be looking
+ * at it. The old rule was "resize the PTY to the LARGEST size any live client
+ * wants", so a wide window could never be clipped by a narrow one. It has a
+ * failure mode that is far worse than the gutter it was avoiding:
+ *
+ *   the PTY is told it has 134 columns, the viewer's xterm has 115, so every
+ *   line the agent draws is ~19 characters too long. xterm soft-wraps it, and
+ *   that 19-character tail lands in the LEFT-HAND columns of the next row —
+ *   on top of the text already there. The screen fills with ragged fragments
+ *   down the left edge and the reading order is destroyed.
+ *
+ * A terminal emulator cannot show more columns than it has. Every multiplexer
+ * that has ever solved this (screen, tmux) solved it the same way: the SMALLEST
+ * attached viewer defines the grid. A viewer wider than the grid gets unused
+ * space on the right, which is cosmetic and self-explanatory; a viewer narrower
+ * than the grid gets corruption, which is neither.
+ *
+ * So: the agreed size is the per-axis MINIMUM over the viewports that live
+ * clients have actually declared. Only the desktop client declares one (the
+ * mobile client is a passive viewer — it adopts the server's `cols` and shrinks
+ * its own font to fit), so attaching a phone never narrows the desktop.
+ *
+ * Two rules keep it from going stale, which was the other half of the bug:
+ *
+ *   - a viewport belongs to the SOCKET, not to a tab. Every tab in a session
+ *     shares one terminal area on screen, so one measurement describes them all
+ *     and a tab you have never visited is still sized correctly.
+ *   - when a socket goes away its viewport goes with it. The old code recorded
+ *     per-tab sizes and only ever recomputed on an inbound resize, so a window
+ *     that had since been closed went on pinning the PTY wide forever.
+ */
+
+const MIN_COLS = 2;
+const MIN_ROWS = 2;
+
+/** Normalise a client-declared viewport, or null if it isn't usable. */
+function normalizeViewport(cols, rows) {
+    const c = Math.trunc(Number(cols));
+    const r = Math.trunc(Number(rows));
+    if (!Number.isFinite(c) || !Number.isFinite(r)) return null;
+    if (c < MIN_COLS || r < MIN_ROWS) return null;
+    return { cols: c, rows: r };
+}
+
+/**
+ * The viewports of every socket that is still open and has declared one.
+ * `sockets` is any iterable of ws-like objects carrying `_viewport`.
+ */
+function liveViewports(sockets) {
+    const out = [];
+    for (const ws of sockets || []) {
+        if (!ws || ws.readyState !== 1 /* OPEN */) continue;
+        const vp = ws._viewport;
+        if (!vp) continue;
+        const norm = normalizeViewport(vp.cols, vp.rows);
+        if (norm) out.push(norm);
+    }
+    return out;
+}
+
+/**
+ * The grid every attached viewer can render without wrapping: the per-axis
+ * minimum. Returns null when nobody has declared anything, which means "leave
+ * the PTY exactly as it is" — never "fall back to a default", because guessing
+ * here is how a tab ends up at the 120x32 spawn size while you look at it.
+ */
+function agreedSize(viewports) {
+    let cols = 0, rows = 0;
+    for (const vp of viewports) {
+        cols = cols ? Math.min(cols, vp.cols) : vp.cols;
+        rows = rows ? Math.min(rows, vp.rows) : vp.rows;
+    }
+    if (!cols || !rows) return null;
+    return { cols, rows };
+}
+
+module.exports = { MIN_COLS, MIN_ROWS, normalizeViewport, liveViewports, agreedSize };

--- a/server/src/terminalReplay.js
+++ b/server/src/terminalReplay.js
@@ -1,0 +1,53 @@
+const { MSG, frame } = require('./protocol');
+
+const REPLAY_HIGH_WATER = 512 * 1024;
+
+// Yield between tab snapshots so heartbeats can interleave, and wait for the
+// socket to drain before adding another large frame. Until a tab's snapshot
+// is sent, Session.sendTerminalData suppresses its live frames on THIS socket.
+// Reading scrollback at send time includes those bytes once, in order, without
+// an extra unbounded queue. Existing sockets keep streaming normally.
+function streamBackgroundReplay(ws, session, tabList, activeId, {
+    schedule = setImmediate,
+    wait = setTimeout,
+} = {}) {
+    const ids = tabList.map(t => t.id).filter(id => id !== activeId);
+    if (!ids.length) return;
+    const pending = new Set(ids);
+    ws._pendingReplayTabs = pending;
+    let i = 0;
+    let stopped = false;
+
+    const finish = () => {
+        stopped = true;
+        pending.clear();
+        if (ws._pendingReplayTabs === pending) delete ws._pendingReplayTabs;
+        if (typeof ws.removeListener === 'function') ws.removeListener('close', finish);
+    };
+    if (typeof ws.once === 'function') ws.once('close', finish);
+
+    const sendNext = () => {
+        if (stopped) return;
+        if (ws.readyState !== 1 || ws._pendingReplayTabs !== pending) { finish(); return; }
+        if (i >= ids.length) { finish(); return; }
+        const id = ids[i];
+        // A tab can close while another replay is draining. Its SNAPSHOT has
+        // already removed it on the client, so skip it without delaying others.
+        if (session.tabMgr.get(id)) {
+            if (ws.bufferedAmount > REPLAY_HIGH_WATER) { wait(sendNext, 50); return; }
+            const data = session.tabMgr.scrollback(id);
+            if (data && data.length) {
+                try { ws.send(frame(MSG.REPLAY, { id, data })); }
+                catch (_) { finish(); return; }
+            }
+        }
+        // Snapshot enqueue and release happen in one event-loop turn: the next
+        // PTY callback can only enqueue live bytes after this tab's replay.
+        pending.delete(id);
+        i++;
+        if (i < ids.length) schedule(sendNext); else finish();
+    };
+    schedule(sendNext);
+}
+
+module.exports = { streamBackgroundReplay, REPLAY_HIGH_WATER };

--- a/server/test/termBatch.test.js
+++ b/server/test/termBatch.test.js
@@ -1,0 +1,186 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { TermBatcher } = require('../src/termBatch');
+const { MSG, parse } = require('../src/protocol');
+
+class Socket {
+    constructor(caps) {
+        this.readyState = 1;
+        this.frames = [];
+        if (caps) this._caps = caps;
+    }
+    send(raw) { this.frames.push(parse(raw)); }
+}
+
+const batching = () => new Socket({ termBatch: true });
+
+// delayMs 0 uses setImmediate, so one await of a macrotask is enough.
+const tick = () => new Promise(r => setImmediate(() => setImmediate(r)));
+
+test('many chunks across many tabs become ONE frame', async () => {
+    const ws = batching();
+    const b = new TermBatcher({ sockets: () => [ws], delayMs: 0, bgDelayMs: 0 });
+    for (let i = 0; i < 10; i++) {
+        b.push(1, 'a' + i);
+        b.push(2, 'b' + i);
+        b.push(3, 'c' + i);
+    }
+    await tick();
+    assert.equal(ws.frames.length, 1, 'thirty chunks, one frame');
+    const f = ws.frames[0];
+    assert.equal(f.t, MSG.TERM_BATCH);
+    assert.equal(f.d.items.length, 3);
+    const byId = Object.fromEntries(f.d.items.map(i => [i.id, i.data]));
+    assert.equal(byId[1], 'a0a1a2a3a4a5a6a7a8a9', 'order within a tab is preserved');
+    assert.equal(byId[2], 'b0b1b2b3b4b5b6b7b8b9');
+    assert.equal(byId[3], 'c0c1c2c3c4c5c6c7c8c9');
+});
+
+test('a client that has not opted in still gets one TERM_DATA per tab', async () => {
+    const legacy = new Socket();
+    const modern = batching();
+    const b = new TermBatcher({ sockets: () => [legacy, modern], delayMs: 0, bgDelayMs: 0 });
+    b.push(1, 'x');
+    b.push(2, 'y');
+    await tick();
+    assert.deepEqual(legacy.frames.map(f => f.t), [MSG.TERM_DATA, MSG.TERM_DATA]);
+    assert.deepEqual(legacy.frames.map(f => f.d.data), ['x', 'y']);
+    assert.deepEqual(modern.frames.map(f => f.t), [MSG.TERM_BATCH]);
+});
+
+test('a socket awaiting replay for a tab is not sent that tab live', async () => {
+    const ws = batching();
+    ws._pendingReplayTabs = new Set([2]);
+    const b = new TermBatcher({ sockets: () => [ws], delayMs: 0, bgDelayMs: 0 });
+    b.push(1, 'keep');
+    b.push(2, 'drop');
+    await tick();
+    assert.equal(ws.frames.length, 1);
+    assert.deepEqual(ws.frames[0].d.items, [{ id: 1, data: 'keep' }]);
+});
+
+test('a socket awaiting replay for every pending tab gets no frame at all', async () => {
+    const ws = batching();
+    ws._pendingReplayTabs = new Set([1]);
+    const b = new TermBatcher({ sockets: () => [ws], delayMs: 0, bgDelayMs: 0 });
+    b.push(1, 'drop');
+    await tick();
+    assert.equal(ws.frames.length, 0);
+});
+
+test('closed sockets are skipped', async () => {
+    const ws = batching();
+    ws.readyState = 3;
+    const b = new TermBatcher({ sockets: () => [ws], delayMs: 0, bgDelayMs: 0 });
+    b.push(1, 'x');
+    await tick();
+    assert.equal(ws.frames.length, 0);
+});
+
+test('share viewers keep the unbatched per-tab frame', async () => {
+    const seen = [];
+    const b = new TermBatcher({
+        sockets: () => [],
+        onShare: (id, f) => seen.push([id, parse(f)]),
+        delayMs: 0, bgDelayMs: 0,
+    });
+    b.push(7, 'hello');
+    await tick();
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0][0], 7);
+    assert.equal(seen[0][1].t, MSG.TERM_DATA);
+    assert.equal(seen[0][1].d.data, 'hello');
+});
+
+test('a send that throws does not stop the other sockets', async () => {
+    const bad = batching();
+    bad.send = () => { throw new Error('gone'); };
+    const good = batching();
+    const b = new TermBatcher({ sockets: () => [bad, good], delayMs: 0, bgDelayMs: 0 });
+    b.push(1, 'x');
+    await tick();
+    assert.equal(good.frames.length, 1);
+});
+
+test('destroy flushes what is queued', () => {
+    const ws = batching();
+    const b = new TermBatcher({ sockets: () => [ws], delayMs: 50, bgDelayMs: 50 });
+    b.push(1, 'last words');
+    assert.equal(ws.frames.length, 0, 'still waiting on the timer');
+    b.destroy();
+    assert.equal(ws.frames.length, 1);
+    assert.equal(ws.frames[0].d.items[0].data, 'last words');
+});
+
+test('flush with nothing pending is a no-op', () => {
+    const ws = batching();
+    const b = new TermBatcher({ sockets: () => [ws], delayMs: 0, bgDelayMs: 0 });
+    b.flush();
+    assert.equal(ws.frames.length, 0);
+});
+
+test('the timer restarts after a flush', async () => {
+    const ws = batching();
+    const b = new TermBatcher({ sockets: () => [ws], delayMs: 0, bgDelayMs: 0 });
+    b.push(1, 'first');
+    await tick();
+    b.push(1, 'second');
+    await tick();
+    assert.deepEqual(ws.frames.map(f => f.d.items[0].data), ['first', 'second']);
+});
+
+test('the tab on screen flushes every tick; the rest wait for their own window', async () => {
+    const ws = batching();
+    let clock = 1000;
+    const b = new TermBatcher({
+        sockets: () => [ws], activeTab: () => 1,
+        delayMs: 0, bgDelayMs: 100, now: () => clock,
+    });
+    // The first flush opens the background window, so it carries both.
+    b.push(1, 'visible');
+    b.push(2, 'hidden');
+    await tick();
+    assert.deepEqual(ws.frames[0].d.items, [{ id: 1, data: 'visible' }, { id: 2, data: 'hidden' }]);
+
+    // Inside that window only the tab on screen keeps going out; nothing is
+    // painting the others, so holding them costs nothing and saves a frame.
+    for (const n of ['a', 'b', 'c']) {
+        b.push(1, n);
+        b.push(2, n);
+        clock += 10;
+        await tick();
+    }
+    assert.deepEqual(ws.frames.slice(1).map(f => f.d.items), [
+        [{ id: 1, data: 'a' }], [{ id: 1, data: 'b' }], [{ id: 1, data: 'c' }],
+    ], 'three visible frames, zero background frames');
+
+    // Once the window elapses the held chunks go as ONE item.
+    clock += 100;
+    b.flush();
+    assert.deepEqual(ws.frames[4].d.items, [{ id: 2, data: 'abc' }]);
+});
+
+test('a held background tab is not forgotten when nothing else arrives', async () => {
+    const ws = batching();
+    let clock = 1000;
+    const b = new TermBatcher({
+        sockets: () => [ws], activeTab: () => 1,
+        delayMs: 0, bgDelayMs: 40, now: () => clock,
+    });
+    b.push(2, 'hidden');
+    await tick();                     // first tick: the window has not elapsed
+    assert.equal(ws.frames.length, 0);
+    clock += 60;
+    await new Promise(r => setTimeout(r, 60));
+    assert.equal(ws.frames.length, 1, 'it re-armed for itself');
+    assert.deepEqual(ws.frames[0].d.items, [{ id: 2, data: 'hidden' }]);
+});
+
+test('destroy flushes background tabs too', () => {
+    const ws = batching();
+    const b = new TermBatcher({ sockets: () => [ws], activeTab: () => 1, delayMs: 5, bgDelayMs: 5000 });
+    b.push(2, 'would have waited five seconds');
+    b.destroy();
+    assert.equal(ws.frames.length, 1);
+    assert.equal(ws.frames[0].d.items[0].data, 'would have waited five seconds');
+});

--- a/server/test/termGeometry.test.js
+++ b/server/test/termGeometry.test.js
@@ -1,0 +1,51 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { normalizeViewport, liveViewports, agreedSize } = require('../src/termGeometry');
+
+const sock = (cols, rows, readyState = 1) => ({ readyState, _viewport: cols == null ? null : { cols, rows } });
+
+test('normalizeViewport rejects anything a terminal cannot be', () => {
+    assert.deepEqual(normalizeViewport(115, 53), { cols: 115, rows: 53 });
+    assert.deepEqual(normalizeViewport('115', '53'), { cols: 115, rows: 53 });
+    assert.deepEqual(normalizeViewport(115.9, 53.9), { cols: 115, rows: 53 });
+    assert.equal(normalizeViewport(1, 53), null);
+    assert.equal(normalizeViewport(115, 1), null);
+    assert.equal(normalizeViewport(NaN, 53), null);
+    assert.equal(normalizeViewport(undefined, undefined), null);
+});
+
+test('liveViewports ignores closed sockets and sockets that never declared', () => {
+    const vps = liveViewports([
+        sock(115, 53),
+        sock(134, 61, 3 /* CLOSED */),
+        sock(null),
+        null,
+        sock(100, 40),
+    ]);
+    assert.deepEqual(vps, [{ cols: 115, rows: 53 }, { cols: 100, rows: 40 }]);
+});
+
+test('the smallest attached viewer defines the grid, per axis', () => {
+    // The bug this exists to prevent: a 134-column PTY drawn into a 115-column
+    // emulator wraps every line, and the tail lands on the next row's left.
+    assert.deepEqual(agreedSize([{ cols: 134, rows: 61 }, { cols: 115, rows: 53 }]), { cols: 115, rows: 53 });
+    // Axes are independent — a tall narrow viewer and a short wide one agree
+    // on the rectangle both can actually show.
+    assert.deepEqual(agreedSize([{ cols: 160, rows: 30 }, { cols: 100, rows: 50 }]), { cols: 100, rows: 30 });
+});
+
+test('a single viewer gets exactly what it asked for', () => {
+    assert.deepEqual(agreedSize([{ cols: 115, rows: 53 }]), { cols: 115, rows: 53 });
+});
+
+test('nobody attached means leave the PTY alone, never guess a default', () => {
+    assert.equal(agreedSize([]), null);
+});
+
+test('a departing viewer stops constraining the grid', () => {
+    const wide = sock(134, 61);
+    const narrow = sock(100, 40);
+    assert.deepEqual(agreedSize(liveViewports([wide, narrow])), { cols: 100, rows: 40 });
+    narrow.readyState = 3;   // the narrow window closes
+    assert.deepEqual(agreedSize(liveViewports([wide, narrow])), { cols: 134, rows: 61 });
+});

--- a/server/test/terminalClient.test.js
+++ b/server/test/terminalClient.test.js
@@ -1,0 +1,347 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+// Exercise the shipped browser class without booting Shell, a browser, or PTYs.
+// These fakes control only DOM geometry, xterm's asynchronous write boundary,
+// and its option-change contract; all queueing and fitting is production code.
+const source = fs.readFileSync(path.join(__dirname, '../../web/public/assets/app.js'), 'utf8');
+const start = source.indexOf('class TabRuntime {');
+const end = source.indexOf('class Shell {', start);
+assert.ok(start >= 0 && end > start, 'locate the actual TabRuntime class');
+const classSource = source.slice(start, end);
+
+function harness({ width = 1000, height = 500, cell = { width: 10, height: 20 } } = {}) {
+    const frames = new Map();
+    const timers = new Map();
+    let nextTask = 1;
+    let canvasMeasurements = 0;
+    let fontCell = null;
+
+    class Element {
+        constructor() {
+            this.clientWidth = width;
+            this.clientHeight = height;
+            this.children = [];
+            this.style = {};
+            this.dataset = {};
+        }
+        appendChild(child) { this.children.push(child); }
+        getBoundingClientRect() { return { width: this.clientWidth, height: this.clientHeight }; }
+        querySelector() { return null; }
+        addEventListener() {}
+        remove() {}
+    }
+
+    class Terminal {
+        constructor(options) {
+            this.cols = 80;
+            this.rows = 24;
+            this.writes = []; // Writes accepted by xterm, still awaiting its parser.
+            this.resizes = [];
+            this.optionChanges = [];
+            this.openCount = 0;
+            this.resetCount = 0;
+            this._core = { _renderService: { dimensions: { css: { cell } } } };
+            this.options = new Proxy({ ...options }, {
+                set: (target, key, value) => {
+                    // xterm 5.3 does not dispatch an event for a same-value set.
+                    if (target[key] === value) return true;
+                    target[key] = value;
+                    this.optionChanges.push({ key, value });
+                    if (key === 'fontFamily' && fontCell) this.setCell(fontCell);
+                    return true;
+                },
+            });
+        }
+        loadAddon() {}
+        open(container) { this.element = container; this.openCount++; }
+        onRender() {}
+        onScroll() {}
+        onData() {}
+        onResize(listener) { this.resizeListener = listener; }
+        onTitleChange() {}
+        write(data) { this.writes.push(data); }
+        reset() { this.resetCount++; }
+        resize(cols, rows) {
+            this.cols = cols;
+            this.rows = rows;
+            this.resizes.push({ cols, rows });
+            if (this.resizeListener) this.resizeListener({ cols, rows });
+        }
+        setCell(next) { this._core._renderService.dimensions.css.cell = next; }
+    }
+
+    const context = {
+        Terminal,
+        FitAddon: { FitAddon: class {} },
+        WebLinksAddon: { WebLinksAddon: class {} },
+        el: () => new Element(),
+        getSettings: () => ({ termFontSize: 14, cursorBlink: false, theme: 'dark' }),
+        resolveTheme: value => value,
+        xtermTheme: () => ({}),
+        tr: () => 'terminal',
+        PERF: { on: false },
+        window: {},
+        performance: { now: () => 1000 },
+        getComputedStyle: () => ({ paddingLeft: '0', paddingRight: '0', paddingTop: '0', paddingBottom: '0' }),
+        // Deliberately different from renderer cell width: a glyph measurement
+        // misses letter spacing and device-pixel rounding in the painted grid.
+        document: { createElement: () => ({ getContext: () => ({
+            measureText: () => { canvasMeasurements++; return { width: 7.5 }; },
+        }) }) },
+        requestAnimationFrame: fn => { const id = nextTask++; frames.set(id, fn); return id; },
+        cancelAnimationFrame: id => frames.delete(id),
+        setTimeout: fn => { const id = nextTask++; timers.set(id, fn); return id; },
+        clearTimeout: id => timers.delete(id),
+    };
+    const Runtime = vm.runInNewContext(classSource + '\nTabRuntime;', context);
+    const rt = new Runtime(1, 'test');
+    return {
+        rt,
+        Runtime,
+        context,
+        get canvasMeasurements() { return canvasMeasurements; },
+        get scheduledCount() { return frames.size + timers.size; },
+        setFontCell: next => { fontCell = next; },
+        show: (w = width, h = height) => { rt.container.clientWidth = w; rt.container.clientHeight = h; },
+        drain() {
+            // Run callbacks in registration order, respecting cancellations.
+            for (let turns = 0; frames.size || timers.size; turns++) {
+                assert.ok(turns < 20, 'bounded browser callback schedule');
+                const id = Math.min(...frames.keys(), ...timers.keys());
+                const queue = frames.has(id) ? frames : timers;
+                const callback = queue.get(id);
+                queue.delete(id);
+                callback();
+            }
+        },
+    };
+}
+
+test('terminal client: reconnect drops obsolete app queues and orders RIS after accepted xterm writes', () => {
+    const h = harness();
+    const { rt } = h;
+    rt.fitNow();
+    rt.write('already accepted by xterm');
+    rt._flushWrites();
+    rt.write('obsolete pending frame');
+    rt.queueReplay('obsolete hidden history');
+    assert.ok(h.scheduledCount > 0);
+
+    rt.resetReplay('replacement snapshot');
+    assert.equal(h.scheduledCount, 0, 'cancel callbacks belonging to obsolete output');
+    assert.equal(rt.term.resetCount, 0, 'never reset synchronously ahead of queued xterm parsing');
+    assert.deepEqual(rt.term.writes, ['already accepted by xterm']);
+    assert.equal(rt.flushPendingReplay(), true);
+    rt.write('live after snapshot');
+    h.drain();
+
+    assert.deepEqual(rt.term.writes, [
+        'already accepted by xterm',
+        '\x18\x1bcreplacement snapshot',
+        'live after snapshot',
+    ]);
+    assert.equal(rt.flushPendingReplay(), false, 'replacement reset is emitted only once');
+});
+
+test('terminal client: an empty reconnect snapshot still clears the previous screen in order', () => {
+    const { rt } = harness();
+    rt.fitNow();
+    rt.resetReplay();
+    assert.equal(rt.flushPendingReplay(), true);
+    assert.deepEqual(rt.term.writes, ['\x18\x1bc']);
+    assert.equal(rt.flushPendingReplay(), false);
+});
+
+test('terminal client: one oversized replay is bounded and resumes at a complete ANSI boundary', () => {
+    const { rt, Runtime } = harness();
+    rt.fitNow();
+    rt.queueReplay('old queued history');
+    const suffix = '\x1b[32mretained\x1b[0m';
+    rt.queueReplay('x'.repeat(Runtime.REPLAY_CAP + 20) + suffix);
+    assert.ok(rt._replayLen <= Runtime.REPLAY_CAP, 'single-frame history respects the cap');
+    assert.ok(rt._replayChunks.join('').length <= Runtime.REPLAY_CAP);
+    rt.flushPendingReplay();
+    assert.deepEqual(rt.term.writes, ['\x18\x1b[0m' + suffix]);
+});
+
+test('terminal client: chunk eviction repairs a partial command even when retained bytes are below the cap', () => {
+    const { rt, Runtime } = harness();
+    rt.fitNow();
+    rt.queueReplay('x'.repeat(Runtime.REPLAY_CAP - 20) + '\x1b[');
+    rt.queueReplay('31mBROKEN\n' + '\x1b[34mkept\x1b[0m' + 'z'.repeat(32));
+    assert.ok(rt._replayLen < Runtime.REPLAY_CAP, 'eviction can leave less than a full buffer');
+    rt.flushPendingReplay();
+    assert.deepEqual(rt.term.writes, ['\x18\x1b[0m\x1b[34mkept\x1b[0m' + 'z'.repeat(32)]);
+});
+
+test('terminal client: intact ANSI sequences split across small chunks are preserved byte-for-byte', () => {
+    const { rt } = harness();
+    rt.fitNow();
+    const chunks = ['before\x1b[', '31mred\x1b[0', 'm\r\nafter'];
+    chunks.forEach(chunk => rt.queueReplay(chunk));
+    rt.flushPendingReplay();
+    assert.deepEqual(rt.term.writes, [chunks.join('')]);
+});
+
+test('terminal client: missing renderer metrics keep replay and live output queued until fitting succeeds', () => {
+    for (const cell of [null, { width: 0, height: 20 }, { width: 10, height: NaN }]) {
+        const { rt } = harness({ cell });
+        rt.queueReplay('history');
+        rt.fitNow();
+        assert.equal(rt._everFit, false);
+        assert.equal(rt.flushPendingReplay(), false);
+        rt.write('live');
+        assert.deepEqual(rt.term.writes, []);
+        assert.deepEqual(rt.term.resizes, []);
+
+        rt.term.setCell({ width: 10, height: 20 });
+        assert.equal(rt.flushPendingReplay(), true);
+        assert.equal(rt._everFit, true);
+        assert.deepEqual(rt.term.writes, ['historylive']);
+    }
+});
+
+test('terminal client: hidden containers do not open, claim a fit, or consume replay', () => {
+    const h = harness({ width: 0, height: 0 });
+    const { rt } = h;
+    rt.queueReplay('history');
+    rt.fitNow();
+    rt.write('live');
+    assert.equal(rt._everFit, false);
+    assert.equal(rt.term.openCount, 0);
+    assert.deepEqual(rt.term.writes, []);
+    assert.equal(rt.flushPendingReplay(), false);
+
+    h.show(1000, 500);
+    assert.equal(rt.flushPendingReplay(), true);
+    assert.equal(rt.term.openCount, 1);
+    assert.deepEqual(rt.term.writes, ['historylive']);
+});
+
+test('terminal client: dirty fonts trigger real option events once the terminal is visible', () => {
+    const h = harness();
+    const { rt } = h;
+    rt.fitNow();
+    const family = rt.term.options.fontFamily;
+    rt.term.options.fontFamily = family;
+    assert.equal(rt.term.optionChanges.length, 0, 'fake models xterm ignoring equal assignments');
+
+    h.setFontCell({ width: 12.5, height: 20 });
+    h.show(0, 0);
+    rt.invalidateFontMetrics();
+    rt.fitNow();
+    assert.equal(rt.term.optionChanges.length, 0, 'defer measurement while hidden');
+    assert.equal(rt._fontMetricsDirty, true);
+
+    h.show();
+    rt.fitNow();
+    assert.equal(rt.term.optionChanges.length, 2, 'change the option then restore the original');
+    assert.ok(rt.term.optionChanges.every(change => change.key === 'fontFamily'));
+    assert.notEqual(rt.term.optionChanges[0].value, family);
+    assert.equal(rt.term.options.fontFamily, family);
+    assert.equal(rt.term.cols, 80, 'fit uses the refreshed 12.5px cell');
+    assert.equal(rt._fontMetricsDirty, false);
+    const resizeCount = rt.term.resizes.length;
+    rt.fitNow();
+    assert.equal(rt.term.optionChanges.length, 2, 'stable fonts do not churn option events');
+    assert.equal(rt.term.resizes.length, resizeCount);
+});
+
+test('terminal client: fit uses painted cells including spacing and repeated stable fits do not resize', () => {
+    const h = harness({ cell: { width: 10.5, height: 20 } });
+    const { rt } = h;
+    rt.term.options.letterSpacing = 3;
+    const size = rt.fitNow();
+    assert.equal(size.cols, 95); // floor(1000 / 10.5), not floor(1000 / 7.5 glyph width)
+    assert.equal(size.rows, 25);
+    assert.equal(h.canvasMeasurements, 0);
+    assert.deepEqual(rt.term.resizes, [{ cols: 95, rows: 25 }]);
+    rt.fitNow();
+    rt.fitNow();
+    assert.equal(rt.term.resizes.length, 1);
+    assert.equal(h.context.window.__soaGrid.cellW, 10.5);
+});
+
+test('terminal client: resizing A to B and back to A cancels the stale pending B notification', () => {
+    const h = harness();
+    const sent = [];
+    h.rt.attach(() => {}, (cols, rows) => sent.push({ cols, rows }));
+    h.rt.fitNow();
+    h.drain();
+    assert.deepEqual(sent, [{ cols: 100, rows: 25 }]);
+
+    h.show(1200, 500);
+    h.rt.fitNow();
+    assert.ok(h.scheduledCount > 0, 'B is waiting in the resize debounce');
+    h.show(1000, 500);
+    h.rt.fitNow();
+    h.drain();
+    assert.deepEqual(sent, [{ cols: 100, rows: 25 }], 'server remains at the latest local size A');
+    assert.equal(h.rt.term.cols, 100);
+});
+
+test('terminal client: a lone viewer still renders and reports its own measurement', () => {
+    const h = harness({ width: 1000, height: 500, cell: { width: 10, height: 20 } });
+    const { rt } = h;
+    const reported = [];
+    rt.attach(() => {}, (cols, rows) => reported.push({ cols, rows }));
+    rt.fitNow();
+    h.drain();
+    assert.deepEqual({ cols: rt.term.cols, rows: rt.term.rows }, { cols: 100, rows: 25 });
+    assert.deepEqual(reported, [{ cols: 100, rows: 25 }]);
+});
+
+test('terminal client: the daemon\'s grid is what gets rendered, and is never echoed back', () => {
+    const h = harness({ width: 1000, height: 500, cell: { width: 10, height: 20 } });
+    const { rt } = h;
+    const reported = [];
+    rt.attach(() => {}, (cols, rows) => reported.push({ cols, rows }));
+    rt.fitNow();
+    h.drain();
+    reported.length = 0;
+
+    // Another, narrower window attaches: the PTY is now 84x20 for everyone.
+    // Rendering at our own 100 columns is the left-hand corruption bug — the
+    // agent's 84-column lines would be drawn into a 100-column grid, and on the
+    // way back every line longer than 84 would wrap onto the row below.
+    assert.equal(rt.adoptGrid(84, 20), true);
+    h.drain();
+    assert.deepEqual({ cols: rt.term.cols, rows: rt.term.rows }, { cols: 84, rows: 20 });
+    assert.deepEqual(reported, [], 'an adopted grid is an answer, not a request');
+
+    // Re-fitting must not fight the adopted grid back to 100. The request is
+    // unchanged, so nothing new is sent — but the request on record is still
+    // 100x25, not the 84x20 we are drawing at, which is what stops the reported
+    // size ratcheting down to the minimum a little more every round.
+    rt.fitNow();
+    h.drain();
+    assert.deepEqual({ cols: rt.term.cols, rows: rt.term.rows }, { cols: 84, rows: 20 });
+    assert.deepEqual(reported, [], 'an unchanged request is not re-sent');
+
+    // A genuine change to OUR window is still reported, at our size.
+    h.show(1200, 500);
+    rt.fitNow();
+    h.drain();
+    assert.deepEqual({ cols: rt.term.cols, rows: rt.term.rows }, { cols: 84, rows: 20 });
+    assert.deepEqual(reported, [{ cols: 120, rows: 25 }]);
+
+    // The narrow window leaves; the daemon reopens the grid.
+    assert.equal(rt.adoptGrid(100, 25), true);
+    h.drain();
+    assert.deepEqual({ cols: rt.term.cols, rows: rt.term.rows }, { cols: 100, rows: 25 });
+});
+
+test('terminal client: adopting the grid already on screen changes nothing', () => {
+    const h = harness({ width: 1000, height: 500, cell: { width: 10, height: 20 } });
+    const { rt } = h;
+    rt.attach(() => {}, () => {});
+    rt.fitNow();
+    h.drain();
+    const before = rt.term.resizes.length;
+    assert.equal(rt.adoptGrid(100, 25), false);
+    assert.equal(rt.term.resizes.length, before, 'no redundant SIGWINCH-inducing resize');
+});

--- a/server/test/terminalReplay.test.js
+++ b/server/test/terminalReplay.test.js
@@ -1,0 +1,158 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+const { Session } = require('../src/sessionStore');
+const { Tab, TabManager } = require('../src/tabManager');
+const { MSG, frame, parse } = require('../src/protocol');
+const { streamBackgroundReplay, REPLAY_HIGH_WATER } = require('../src/terminalReplay');
+
+class Socket extends EventEmitter {
+    constructor() {
+        super();
+        this.readyState = 1;
+        this.bufferedAmount = 0;
+        this.frames = [];
+    }
+    send(raw) { this.frames.push(parse(raw)); }
+    close() { this.readyState = 3; this.emit('close'); }
+}
+
+function setup(ids = [1, 2, 3]) {
+    const session = new Session('replay-test');
+    session.tabMgr = new TabManager();
+    for (const id of ids) {
+        const tab = new Tab({ id, scrollbackBytes: 1024 });
+        session.tabMgr.tabs.set(id, tab);
+        session.tabMgr.order.push(id);
+    }
+    const socket = new Socket();
+    const established = new Socket();
+    session.attachSocket(socket);
+    session.attachSocket(established);
+    const scheduled = [];
+    const waits = [];
+    const scheduler = {
+        schedule(fn) { scheduled.push(fn); },
+        wait(fn, ms) { waits.push(ms); scheduled.push(fn); },
+    };
+    const seed = (id, data) => session.tabMgr.get(id).scrollback.push(data);
+    const output = (id, data) => {
+        seed(id, data);
+        session.sendTerminalData(id, frame(MSG.TERM_DATA, { id, data }));
+    };
+    const start = () => streamBackgroundReplay(socket, session, session.tabMgr.list(), 1, scheduler);
+    const step = () => {
+        assert.ok(scheduled.length, 'expected deferred replay work');
+        scheduled.shift()();
+    };
+    return { session, socket, established, scheduled, waits, seed, output, start, step };
+}
+
+function terminalFrames(socket, id) {
+    return socket.frames.filter(f => f.d.id === id && (f.t === MSG.REPLAY || f.t === MSG.TERM_DATA));
+}
+
+test('terminal replay: each snapshot precedes live bytes without duplicating its tail', () => {
+    const h = setup();
+    h.seed(2, 'old-2\r\n');
+    h.seed(3, 'old-3\r\n');
+    h.start();
+
+    h.output(2, 'during-2\r\n');
+    h.output(3, 'during-3\r\n');
+    h.output(1, 'active\r\n');
+    assert.deepEqual(h.socket.frames.map(f => f.d.id), [1], 'active tab streams during replay');
+    assert.deepEqual(h.established.frames.map(f => f.d.id), [2, 3, 1], 'existing clients receive every live chunk');
+
+    h.step(); // replay tab 2 only; yield before tab 3
+    h.output(2, 'after-2\r\n');
+    h.output(3, 'later-3\r\n');
+    h.step();
+    h.output(3, 'after-3\r\n');
+
+    assert.deepEqual(terminalFrames(h.socket, 2).map(f => [f.t, f.d.data]), [
+        [MSG.REPLAY, 'old-2\r\nduring-2\r\n'],
+        [MSG.TERM_DATA, 'after-2\r\n'],
+    ]);
+    assert.deepEqual(terminalFrames(h.socket, 3).map(f => [f.t, f.d.data]), [
+        [MSG.REPLAY, 'old-3\r\nduring-3\r\nlater-3\r\n'],
+        [MSG.TERM_DATA, 'after-3\r\n'],
+    ]);
+    assert.equal(h.scheduled.length, 0);
+});
+
+test('terminal replay: backpressure pauses snapshots while heartbeats and metadata flow', () => {
+    const h = setup([1, 2]);
+    h.seed(2, 'old\r\n');
+    h.socket.bufferedAmount = REPLAY_HIGH_WATER + 1;
+    h.start();
+    h.step();
+    h.output(2, 'while-blocked\r\n');
+    h.session.send(frame(MSG.PONG, { ts: 1 }));
+    h.session.send(frame(MSG.SNAPSHOT, { tabs: [] }));
+    assert.deepEqual(h.socket.frames.map(f => f.t), [MSG.PONG, MSG.SNAPSHOT]);
+    assert.deepEqual(h.waits, [50]);
+    assert.equal(terminalFrames(h.established, 2)[0].d.data, 'while-blocked\r\n');
+
+    h.socket.bufferedAmount = 0;
+    h.step();
+    h.output(2, 'after-drain\r\n');
+    assert.deepEqual(terminalFrames(h.socket, 2).map(f => f.d.data), [
+        'old\r\nwhile-blocked\r\n', 'after-drain\r\n',
+    ]);
+});
+
+test('terminal replay: vanished and empty tabs do not prevent later replay or live output', () => {
+    const h = setup([1, 2, 3, 4]);
+    h.seed(4, 'last-tab\r\n');
+    h.start();
+    h.session.tabMgr.tabs.delete(2);
+    h.socket.bufferedAmount = REPLAY_HIGH_WATER + 1;
+    h.step(); // vanished tab does not wait for backpressure
+    assert.deepEqual(h.waits, []);
+    h.socket.bufferedAmount = 0;
+    h.step(); // empty tab
+    h.output(3, 'first-byte\r\n');
+    h.step(); // remaining populated tab
+    assert.deepEqual(h.socket.frames.map(f => [f.t, f.d.id, f.d.data]), [
+        [MSG.TERM_DATA, 3, 'first-byte\r\n'],
+        [MSG.REPLAY, 4, 'last-tab\r\n'],
+    ]);
+    assert.equal(h.scheduled.length, 0);
+});
+
+test('terminal replay: closing a socket cancels its pending replay without affecting peers', () => {
+    const h = setup([1, 2]);
+    h.start();
+    h.socket.bufferedAmount = REPLAY_HIGH_WATER + 1;
+    h.step();
+    h.socket.close();
+    h.step();
+    h.output(2, 'still-live\r\n');
+    assert.equal(h.socket.frames.length, 0);
+    assert.equal(h.scheduled.length, 0);
+    assert.equal(h.socket.listenerCount('close'), 0);
+    assert.equal(terminalFrames(h.established, 2)[0].d.data, 'still-live\r\n');
+});
+
+test('terminal replay: a failed send releases replay state and stops scheduling', () => {
+    const h = setup([1, 2]);
+    h.seed(2, 'old\r\n');
+    h.socket.send = () => { throw new Error('socket write failed'); };
+    h.start();
+    h.step();
+    assert.equal(h.scheduled.length, 0);
+    assert.equal(h.socket.listenerCount('close'), 0);
+    h.socket.send = Socket.prototype.send;
+    h.output(2, 'next\r\n');
+    assert.equal(terminalFrames(h.socket, 2)[0].d.data, 'next\r\n');
+});
+
+test('terminal replay: a single active tab needs no replay gate', () => {
+    const h = setup([1]);
+    h.start();
+    h.output(1, 'hello\r\n');
+    assert.equal(h.scheduled.length, 0);
+    assert.equal(h.socket.listenerCount('close'), 0);
+    assert.equal(terminalFrames(h.socket, 1)[0].d.data, 'hello\r\n');
+});

--- a/web/public/assets/app.js
+++ b/web/public/assets/app.js
@@ -16,7 +16,7 @@
  * (scripts/vercel-build.js) rewrites it from env vars.
  */
 
-import { Bridge, INPUT_KIND } from '/assets/bridge.js?v=18';
+import { Bridge, INPUT_KIND } from '/assets/bridge.js?v=19';
 import { AudioFX } from '/assets/audiofx.js?v=18';
 import { mountSidebar, setSidebarHidden } from '/assets/widgets.js?v=47';
 import { t as tr, getLang, setLang, applyStatic, LANGS } from '/assets/i18n.js?v=29';
@@ -220,10 +220,26 @@ class TabRuntime {
         // and flush it on the first successful fit — see flushPendingReplay.
         this._replayChunks = [];
         this._replayLen = 0;
+        this._replayTruncated = false;
+        this._resetPending = false;
         this._wq = [];
         this._wRaf = null;
         this._wTimer = null;
         this._everFit = false;
+        this._fontMetricsDirty = false;
+        // Two different numbers that used to be one, which is why they could
+        // silently disagree:
+        //   _desired  what this window measured it has room for — reported UP
+        //             to the daemon as this viewer's request.
+        //   _authGrid what the daemon says the PTY actually is — the grid we
+        //             must RENDER at, since the agent is drawing for it.
+        // When one viewer is attached they are equal. When they are not, the
+        // emulator follows _authGrid and the spare columns simply go unused;
+        // drawing at _desired instead is what wrapped every line onto the left
+        // of the one below it.
+        this._desired = null;
+        this._authGrid = null;
+        this._suppressReport = false;
         this._renderer = null;
         // absolute buffer line -> 'user' | 'tool' | '' (classified once; a line
         // that has scrolled into history can never change again)
@@ -269,8 +285,16 @@ class TabRuntime {
         let pending = null;
         let lastSent = null;
         this._onResize = (cols, rows) => {
-            if (lastSent && lastSent.cols === cols && lastSent.rows === rows) return;
+            // A grid we adopted from the daemon is an answer, not a request.
+            // Echoing it back would ratchet: the reported size would become the
+            // minimum, which would become the next reported size.
+            if (this._suppressReport) return;
             if (pending) clearTimeout(pending);
+            pending = null;
+            // A drag can return A → B → A before the debounce fires. Cancel B
+            // even if A was already sent, or the PTY ends up at B while xterm
+            // stays at A and subsequent stable fits never correct it.
+            if (lastSent && lastSent.cols === cols && lastSent.rows === rows) return;
             pending = setTimeout(() => {
                 lastSent = { cols, rows };
                 pending = null;
@@ -300,6 +324,13 @@ class TabRuntime {
 
     write(data) {
         if (!data) return;
+        // A visible tab can still be waiting for its first valid measurement.
+        // Keep replay and live bytes in order until there is a real grid.
+        if (!this._everFit || this._resetPending || this._replayChunks.length) {
+            this.queueReplay(data);
+            this.flushPendingReplay();
+            return;
+        }
         this._wq.push(data);
         if (this._wRaf || this._wTimer) return;
         // SCROLLING defers a write; typing must not. The two used to share one
@@ -342,16 +373,36 @@ class TabRuntime {
 
     queueReplay(data) {
         if (!data) return;
+        if (data.length > TabRuntime.REPLAY_CAP) {
+            data = data.slice(-TabRuntime.REPLAY_CAP);
+            this._replayChunks = [];
+            this._replayLen = 0;
+            this._replayTruncated = true;
+        }
         this._replayChunks.push(data);
         this._replayLen += data.length;
         while (this._replayLen > TabRuntime.REPLAY_CAP && this._replayChunks.length > 1) {
             this._replayLen -= this._replayChunks.shift().length;
+            this._replayTruncated = true;
         }
+    }
+
+    resetReplay(data = '') {
+        if (this._wRaf) cancelAnimationFrame(this._wRaf);
+        if (this._wTimer) clearTimeout(this._wTimer);
+        this._wRaf = this._wTimer = null;
+        this._wq = [];
+        this._replayChunks = [];
+        this._replayLen = 0;
+        this._replayTruncated = false;
+        this._resetPending = true;
+        this._bandCache.clear();
+        this.queueReplay(data);
     }
 
     flushPendingReplay() {
         this._flushWrites();   // keep ordering: anything already queued goes first
-        if (!this._replayChunks.length) return false;
+        if (!this._replayChunks.length && !this._resetPending) return false;
         // Only flush once xterm has actually been fit against a real-sized
         // container — otherwise absolute-column escapes in the scrollback
         // land at the wrong column.
@@ -359,17 +410,25 @@ class TabRuntime {
             const rect = this.container.getBoundingClientRect();
             if (rect.width < 2 || rect.height < 2) return false;
             this.fitNow();
+            if (!this._everFit) return false;
         }
         let data = this._replayChunks.join('');
         this._replayChunks = [];
         this._replayLen = 0;
-        // A dropped chunk can leave the buffer starting mid-escape-sequence, so
-        // align to the first newline; a full-screen TUI repaints itself moments
-        // later and the lost prefix self-corrects.
-        if (data.length >= TabRuntime.REPLAY_CAP) {
-            const nl = data.indexOf('\n');
-            if (nl >= 0) data = data.slice(nl + 1);
+        // Chunk eviction is independent of the retained length; remember it
+        // explicitly so a partial command isn't mistaken for ordinary text.
+        if (this._replayTruncated) {
+            // Resume at a control boundary, never in the middle of a UTF-16
+            // character or an ANSI command. Cancel any parser state belonging
+            // to the discarded prefix before feeding the retained stream.
+            const boundary = data.search(/[\x1b\n]/);
+            data = boundary < 0 ? '' : data.slice(boundary + (data[boundary] === '\n' ? 1 : 0));
+            data = '\x18\x1b[0m' + data;
+            this._replayTruncated = false;
         }
+        // Queue RIS with the snapshot, rather than calling reset() while xterm
+        // still has asynchronous writes pending from the previous connection.
+        if (this._resetPending) { data = '\x18\x1bc' + data; this._resetPending = false; }
         this.term.write(data);
         return true;
     }
@@ -620,7 +679,6 @@ class TabRuntime {
     _repaint() {
         const go = () => { try { this.term.refresh(0, this.term.rows - 1); } catch (_) {} };
         go();
-        // fitNow, which measures the cell from the paint — see _cellSize.
         requestAnimationFrame(() => { this.fitNow(); go(); });
     }
 
@@ -630,19 +688,42 @@ class TabRuntime {
         this._renderer = null;
     }
 
-    // ONE resize, from one measurement.
-    //
-    // This used to call FitAddon and then correct it. FitAddon sizes the grid
-    // from xterm's reported cell metric — the metric that is wrong here — so
-    // every fit set the grid to ~102 columns and _fillWidth immediately grew it
-    // back to ~168. Two resizes, the first one wrong, and each one is an
-    // onResize that reaches the PTY as a SIGWINCH: Claude repaints its entire
-    // TUI at the wrong width, then repaints again at the right one. That is the
-    // layout tearing that "fixes itself after a few seconds", and with a
-    // two-second guard re-fitting whenever it sees divergence, it never stopped.
-    //
-    // So FitAddon is gone from this path. Measure the container, derive the cell
-    // from what is actually painted, resize once, and only when it changed.
+    // Invalidate hidden terminals too; their fonts can only be measured once
+    // they become visible. xterm 5.3 ignores same-value option assignments.
+    invalidateFontMetrics() { this._fontMetricsDirty = true; }
+
+    _refreshFontMetrics() {
+        if (!this._fontMetricsDirty) return;
+        const family = this.term.options.fontFamily;
+        // Whitespace changes the option value without selecting another face.
+        // The real option events refresh both character metrics and glyph caches.
+        try { this.term.options.fontFamily = family + ' '; }
+        finally { this.term.options.fontFamily = family; }
+        this._fontMetricsDirty = false;
+    }
+
+    // Take the daemon's authoritative PTY geometry and render at it. Reported
+    // back to nobody — see _suppressReport — and remembered, so the next fit
+    // measures the container for a REQUEST without overwriting the grid.
+    adoptGrid(cols, rows) {
+        this._authGrid = { cols, rows };
+        if (!this._opened) return false;
+        if (this.term.cols === cols && this.term.rows === rows) return false;
+        this._suppressReport = true;
+        try { this.term.resize(cols, rows); }
+        catch (_) { return false; }
+        finally { this._suppressReport = false; }
+        // The agent drew its last frame for the old grid, so what is on screen
+        // now is stale at every width. It repaints on the SIGWINCH the daemon
+        // just delivered; refresh so the reflowed rows are not left half-drawn
+        // in the meantime.
+        try { this.term.refresh(0, this.term.rows - 1); } catch (_) {}
+        return true;
+    }
+
+    // Fit once using the renderer's actual CSS cell size, including device-pixel
+    // rounding and letter spacing. A canvas text measurement is a glyph width,
+    // not a grid cell, and substituting it can make fitting disagree with paint.
     fitNow() {
         if (!this._ensureOpen()) return { cols: this.term.cols, rows: this.term.rows };
         try {
@@ -651,11 +732,24 @@ class TabRuntime {
             const availW = el.clientWidth - (parseFloat(cs.paddingLeft) || 0) - (parseFloat(cs.paddingRight) || 0);
             const availH = el.clientHeight - (parseFloat(cs.paddingTop) || 0) - (parseFloat(cs.paddingBottom) || 0);
             if (availW > 40 && availH > 20) {
+                this._refreshFontMetrics();
                 const cell = this._cellSize();
                 if (cell) {
                     const cols = Math.max(2, Math.floor(availW / cell.w));
                     const rows = Math.max(2, Math.floor(availH / cell.h));
-                    if (cols !== this.term.cols || rows !== this.term.rows) this.term.resize(cols, rows);
+                    this._desired = { cols, rows };
+                    // Render at the PTY's real grid when the daemon has told us
+                    // one; otherwise this window is the only viewer and its own
+                    // measurement is the answer. Either way the REQUEST that
+                    // goes up is what we measured, never what we adopted.
+                    const grid = this._authGrid || this._desired;
+                    if (grid.cols !== this.term.cols || grid.rows !== this.term.rows) {
+                        this._suppressReport = !!this._authGrid;
+                        try { this.term.resize(grid.cols, grid.rows); }
+                        finally { this._suppressReport = false; }
+                    }
+                    if (this._authGrid && this._onResize) this._onResize(cols, rows);
+                    this._everFit = true;
                     // Publish what the fit actually decided. Half a day went
                     // into inferring these four numbers from screenshots; the
                     // terminal can simply say them, and the PERF widget shows
@@ -668,52 +762,19 @@ class TabRuntime {
                     };
                 }
             }
-            this._everFit = true;
             return { cols: this.term.cols, rows: this.term.rows };
         } catch (_) { return { cols: this.term.cols, rows: this.term.rows }; }
     }
 
-    // The cell, measured from the paint wherever possible. xterm's own numbers
-    // are a hint: they are believed only when the painted grid agrees with them,
-    // because the paint is what is on the screen.
+    // xterm's pinned renderer contract is in CSS pixels (not device pixels).
+    // Missing metrics mean wait for layout, not invent a different grid width.
     _cellSize() {
         try {
             const core = this.term._core;
             const dims = core && core._renderService && core._renderService.dimensions;
             const css = dims && dims.css && dims.css.cell;
-            let w = css && css.width, h = css && css.height;
-
-            // Cross-check the width against the FONT — never against the
-            // painted canvas. Dividing the canvas by the column count is a
-            // feedback loop: the canvas is sized from the grid, so whatever
-            // column count the fit last chose is always "confirmed" by it.
-            // Measured live, the same 756px canvas reported a 7.2px cell at 105
-            // columns and a 9px cell at 84 — two stable, wrong answers.
-            //
-            // The font is measured from term.options, which is what xterm was
-            // constructed with. NOT from getComputedStyle: .xterm inherits the
-            // page's display face, so that route measured 16px United Sans and
-            // returned 15.17px per character.
-            const o = this.term.options || {};
-            if (o.fontSize && o.fontFamily) {
-                const ctx = TabRuntime._measureCtx
-                    || (TabRuntime._measureCtx = document.createElement('canvas').getContext('2d'));
-                if (ctx) {
-                    ctx.font = `${o.fontSize}px ${o.fontFamily}`;
-                    const m = ctx.measureText('W'.repeat(100)).width / 100;
-                    // Believe xterm only when it agrees with the font it is
-                    // supposed to be rendering in; otherwise it is running on a
-                    // metric cached before the web font arrived.
-                    if (m > 0.5 && (!(w > 0.5) || Math.abs(w - m) / m > 0.08)) w = m;
-                }
-            }
-            // Height has never been the failure and has no equivalent source,
-            // so fall back to the painted rows only if xterm offers nothing.
-            if (!(h > 0.5) && this.term.element && this.term.rows > 0) {
-                const c = this.term.element.querySelector('.xterm-screen canvas');
-                if (c) h = c.getBoundingClientRect().height / this.term.rows;
-            }
-            if (!(w > 0.5) || !(h > 0.5)) return null;
+            const w = css && css.width, h = css && css.height;
+            if (!Number.isFinite(w) || !Number.isFinite(h) || w <= 0.5 || h <= 0.5) return null;
             return { w, h };
         } catch (_) { return null; }
     }
@@ -1212,23 +1273,12 @@ class Shell {
             this._ro.observe(this.termsEl);
         }
         if (document.fonts && document.fonts.ready) {
-            document.fonts.ready.then(() => {
-                // THE root cause of the dead strip. xterm measures its cell
-                // ONCE, when the terminal is opened, and caches it — and at
-                // that moment Fira Mono has usually not loaded, so it measures
-                // the fallback and keeps that number forever. Every later fit
-                // then divides the container by a cell width the renderer is
-                // not drawing with, and the grid stops short.
-                //
-                // xterm has no public "re-measure" call, but assigning a font
-                // option invalidates the cached metrics, so a no-op assignment
-                // makes it measure again — now with the real face.
-                for (const rt of this.tabs.values()) {
-                    if (!rt._opened) continue;
-                    try { rt.term.options.fontFamily = rt.term.options.fontFamily; } catch (_) {}
-                }
+            const fontsLoaded = () => {
+                for (const rt of this.tabs.values()) rt.invalidateFontMetrics();
                 this._fitActive();
-            }).catch(() => {});
+            };
+            document.fonts.ready.then(fontsLoaded).catch(() => {});
+            document.fonts.addEventListener('loadingdone', fontsLoaded);
         }
 
         this._initRecovery();
@@ -1237,6 +1287,8 @@ class Shell {
         bridge.addEventListener('replay',    e => this._onReplay(e.detail));
         bridge.addEventListener('snapshot',  e => this._onSnapshot(e.detail));
         bridge.addEventListener('term-data', e => this._onTermData(e.detail));
+        bridge.addEventListener('term-batch', e => this._onTermBatch(e.detail));
+        bridge.addEventListener('term-size', e => this._onTermSize(e.detail));
         bridge.addEventListener('term-exit', e => this._onTermExit(e.detail));
         bridge.addEventListener('status',    e => this._onStatus(e.detail));
         bridge.addEventListener('tts',       e => { this._onTTS(e.detail); this._onAgentMessage(e.detail); });
@@ -1359,6 +1411,7 @@ class Shell {
             // cwd never changed stayed unrecorded for the life of the page.
             for (const t of tabs) {
                 this._ensureTab(t.id, t.title);
+                this.tabs.get(t.id).resetReplay();
                 if (t.mem != null) this._tabMem.set(t.id, t.mem);
                 if (t.cwd) this._tabCwd.set(t.id, t.cwd);
             }
@@ -1372,7 +1425,7 @@ class Shell {
                 for (const r of replay) {
                     const rt = this.tabs.get(r.id);
                     if (rt && r.data) {
-                        rt.queueReplay(r.data);
+                        rt.resetReplay(r.data);
                         this._detectAgentFromStream(r.id, r.data);
                         this._pollDirty.add(r.id);
                     }
@@ -1397,7 +1450,13 @@ class Shell {
             // sizes per socket — so everything we told the old one is gone.
             this._sentSize = null;
             const rt = this.tabs.get(target);
-            if (rt && rt._opened) this._broadcastSize(rt.term.cols, rt.term.rows);
+            // The size we REQUEST is what this window measured, not the grid
+            // we adopted — reporting the adopted minimum back would ratchet it
+            // down a little further every time.
+            if (rt && rt._opened) {
+                const want = rt._desired || { cols: rt.term.cols, rows: rt.term.rows };
+                this._broadcastSize(want.cols, want.rows);
+            }
             this._syncTabsUI(tabs);
             // Run agent status detection after HELLO so colors are correct
             // on first load — force a detection pass on all stream buffers
@@ -1427,10 +1486,10 @@ class Shell {
     // path, so absolute-column escapes in the scrollback don't land at 80×24
     // before the tab is sized. Flush immediately if it's the tab on screen.
     _onReplay({ id, data }) {
-        if (id == null || !data) return;
+        if (id == null || typeof data !== 'string') return;
         const rt = this.tabs.get(id);
         if (!rt) return;
-        rt.queueReplay(data);
+        rt.resetReplay(data);
         this._detectAgentFromStream(id, data);
         this._pollDirty.add(id);
         if (id === this.activeId) rt.flushPendingReplay();
@@ -1569,6 +1628,30 @@ class Shell {
             this.audio.play('stdout', 'tab' + id);
         }
         if (PERF.on) ptime('stream total', _s0);
+    }
+
+    // Many tabs' output, coalesced by the daemon into one frame (see
+    // server/src/termBatch.js). Unrolled here rather than re-emitted as N
+    // separate DOM events, because the whole point of the batch is to stop
+    // paying a fixed per-message cost once per chunk per agent.
+    _onTermBatch({ items }) {
+        if (!Array.isArray(items)) return;
+        for (const it of items) {
+            if (it && it.id != null) this._onTermData(it);
+        }
+    }
+
+    // The daemon's answer to "how big is this tab's PTY really". It is the grid
+    // every attached viewer can render — the minimum across them — and it is
+    // the ONLY number the emulator may draw at. Rendering at our own measured
+    // width while the PTY believes it has more columns is the whole left-hand
+    // corruption bug: the agent's lines come back too long, xterm soft-wraps
+    // them, and the overflow lands on top of the next row's first columns.
+    _onTermSize({ id, cols, rows }) {
+        if (id == null || !(cols > 1) || !(rows > 1)) return;
+        const rt = this.tabs.get(id);
+        if (!rt) return;
+        rt.adoptGrid(cols, rows);
     }
 
     _onTermExit({ id, code }) {
@@ -3386,13 +3469,15 @@ class Shell {
         // intentionally do NOT send TERM_RESIZE here: a drag-grown window
         // would otherwise fire 3 redundant resizes per frame and shift any
         // in-flight output.
+        const fitAndReplay = () => { rt.fitNow(); rt.flushPendingReplay(); };
         rt.fitNow();
-        requestAnimationFrame(() => { rt.fitNow(); requestAnimationFrame(() => rt.fitNow()); });
+        requestAnimationFrame(() => { fitAndReplay(); requestAnimationFrame(fitAndReplay); });
         // Also the recovery point for the renderer: on a cold load _activate
         // runs while #shell is still hidden, so the terminal is not open yet and
         // attachRenderer() bails. This path runs again once the container has a
         // real size, which is exactly when the renderer can be created.
         rt.attachRenderer();
+        rt.flushPendingReplay();
         this._broadcastSizeSoon();
     }
 
@@ -3436,7 +3521,13 @@ class Shell {
         this._bcTimer = setTimeout(() => {
             this._bcTimer = null;
             const rt = this.tabs.get(this.activeId);
-            if (rt && rt._opened) this._broadcastSize(rt.term.cols, rt.term.rows);
+            // The size we REQUEST is what this window measured, not the grid
+            // we adopted — reporting the adopted minimum back would ratchet it
+            // down a little further every time.
+            if (rt && rt._opened) {
+                const want = rt._desired || { cols: rt.term.cols, rows: rt.term.rows };
+                this._broadcastSize(want.cols, want.rows);
+            }
         }, 250);
     }
 

--- a/web/public/assets/bridge.js
+++ b/web/public/assets/bridge.js
@@ -5,7 +5,7 @@
  * should survive laptop sleep and flaky wifi without the user having to refresh.
  */
 
-import { MSG, INPUT_KIND, frame, parse } from '/assets/protocol.js?v=18';
+import { MSG, INPUT_KIND, frame, parse } from '/assets/protocol.js?v=19';
 
 export class Bridge extends EventTarget {
     constructor({ url }) {
@@ -47,6 +47,10 @@ export class Bridge extends EventTarget {
             this.backoff = 500;
             this.attempts = 0;
             this._emit('status', { state: 'open' });
+            // Tell the daemon what this socket can decode, before anything else
+            // goes out. Without it we keep getting one frame per chunk per tab,
+            // which is correct but is the cost that scales with agent count.
+            this.input(INPUT_KIND.CLIENT_CAPS, { caps: { termBatch: true } });
             this._ping = setInterval(() => this.send(MSG.PING, { ts: Date.now() }), 20_000);
         });
 

--- a/web/public/assets/protocol.js
+++ b/web/public/assets/protocol.js
@@ -16,6 +16,8 @@ export const MSG = Object.freeze({
     REPLAY:    'replay',
     SNAPSHOT:  'snapshot',
     TERM_DATA: 'term-data',
+    TERM_BATCH:'term-batch',
+    TERM_SIZE: 'term-size',
     TERM_EXIT: 'term-exit',
     NOTICE:    'notice',
     PONG:      'pong',
@@ -50,6 +52,7 @@ export const INPUT_KIND = Object.freeze({
     BROWSER_UNSUBSCRIBE: 'browser-unsubscribe',
     BROWSER_CLICK:       'browser-click',
     WINDOW_CONTROL:      'window-control',
+    CLIENT_CAPS:         'client-caps',
 });
 
 export function frame(type, data, id) {

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -964,7 +964,7 @@ SOA_WEB_PASSWORD=hunter2 npm install &amp;&amp; npm start</pre>
        alive and moving it beats handing every tab its own and losing the lot. -->
   <script src="https://cdn.jsdelivr.net/npm/xterm-addon-webgl@0.16.0/lib/xterm-addon-webgl.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/xterm-addon-canvas@0.5.0/lib/xterm-addon-canvas.js"></script>
-  <script type="module" src="/assets/app.js?v=153"></script>
+  <script type="module" src="/assets/app.js?v=155"></script>
   <script>
     // Cloudflare Web Analytics — loaded only when a token is configured (Vercel
     // env SOA_WEB_CF_ANALYTICS_TOKEN). Skipped on dev / self-host so localhost

--- a/web/public/m/app.js
+++ b/web/public/m/app.js
@@ -1392,6 +1392,16 @@ class App {
                 case 'replay':    this._applyTerminalChunk(msg.d); break;
                 case 'term-data': this._applyTerminalChunk(msg.d); break;
                 case 'term-exit': break;
+                // The daemon now announces a tab's real PTY geometry the moment
+                // it changes, instead of it only riding along on the next
+                // snapshot. This client never resizes the shared PTY — it fits
+                // its own font to whatever `cols` the desktop is drawing at — so
+                // acting on this promptly is what keeps the wrapping identical.
+                case 'term-size':
+                    if (msg.d && msg.d.id === this._activeTabId && msg.d.cols > 1) {
+                        this._fitTerminalFont(msg.d.cols);
+                    }
+                    break;
                 case 'notice':    this._showNotice(msg.d); break;
                 case 'tts':       this._onTTS(msg.d); this._onAgentMessage(msg.d); break;
                 case 'browser-frame': this._onBrowserFrame(msg.d); break;

--- a/web/public/m/sw.js
+++ b/web/public/m/sw.js
@@ -10,7 +10,7 @@
 // wipes memory-only state — harmless here: a meeting's transcript lives in the
 // server-side ledger and the view re-fetches it with `?since=<cursor>`.
 // No new files: MEET is markup + code inside the shell entries already listed.
-const VERSION = 'soa-mobile-v82';
+const VERSION = 'soa-mobile-v83';
 const SHELL = [
     '/',
     '/index.html',


### PR DESCRIPTION
## The bug

The streamed terminal drifts left and overwrites the start of each line.

Measured live, not inferred: the desktop's xterm was **115x53** (`__soaGrid`), the PTY behind the same tab was **134x61** (`stty -f /dev/ttys003 size`). The agent draws 134-column lines into a 115-column emulator, every long line soft-wraps, and the ~19-character tail lands in the **left-hand columns of the row below** — on top of the text already there.

Root cause: the server resized the shared PTY to the **MAX** size any live client wanted. A terminal cannot show more columns than it has, so the wide client was fine and every narrower one got corruption. It stuck because sizes were recorded per-socket-per-tab and only recomputed on an inbound resize — a window that had since closed went on pinning every PTY to its width forever.

## The fix

- `server/src/termGeometry.js` — the **smallest attached viewer** defines the grid, the way every multiplexer solves this. A viewport belongs to the socket, not to a tab, so tabs you have never visited are sized correctly too.
- Recomputed at the three moments the answer can change: an inbound resize, a tab becoming active, a socket closing.
- The daemon announces the result as `MSG.TERM_SIZE`; the client renders at that grid while still *requesting* its own measured size (`_desired` vs `_authGrid`, with the echo suppressed so it cannot ratchet down). Mobile already worked this way and just needed the frame wired in.

Trade-off: a viewer wider than the grid now has unused columns on the right while a smaller one is attached. That is what the MAX rule was avoiding — but a gutter is cosmetic and corruption is not, and only the desktop declares a viewport, so attaching a phone never narrows anything.

Verified end-to-end against a scratch daemon with real PTYs: two viewers at 134x61 and 115x53 → the PTY takes 115x53, **`stty size` inside the shell agrees**, and the grid reopens to 134x61 when the narrow viewer leaves.

## Responsiveness with many agents

Every chunk from every tab was its own frame — a `JSON.stringify`, a `message` event, a `JSON.parse` and a detector pass — a fixed per-message cost that scales with agent count even though 21 of 22 terminals are never painted.

`server/src/termBatch.js` coalesces into one `TERM_BATCH` frame per tick: 12ms for the tab on screen (under the rAF the client already coalesces xterm writes to), 100ms for tabs nothing is rendering. Opt-in per socket via `CLIENT_CAPS`, so share viewers and unreloaded tabs keep the original wire.

| tabs | frames/s before | after | |
|---|---|---|---|
| 12 | 51.1 | 10.1 | 5.0x fewer |
| 22 | 66.8 | 7.3 | **9.2x fewer** |

Same shells, same bytes; the ratio grows with tab count, which is the shape of the original "it gets worse with every tab" complaint.

## Note

This also carries the previously uncommitted terminal-replay work that was sitting in the working tree (`terminalReplay.js`, the reconnect-ordering and font-metric fixes) — this builds directly on it.

209/209 tests pass, including 16 new ones across geometry, batching and grid adoption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
