### PR TITLE
perf(term): echo goes now, scrolling tracks the gesture, background windows stop shrinking the grid

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -333,6 +333,14 @@ app.get('/api/devices', requireAuthed, (req, res) => {
         devices.push({
             connectedAt: ws._connectedAt || null,
             userAgent: ws._userAgent || '',
+            // The grid this viewer has declared it can render, and whether it is
+            // on screen. The PTY is sized to the smallest VISIBLE viewer, so
+            // when a terminal is leaving a black strip down its right this is
+            // the answer to "which window is holding it narrow" — without it,
+            // the only way to find out was to close windows one at a time.
+            viewport: ws._viewport
+                ? { cols: ws._viewport.cols, rows: ws._viewport.rows, hidden: ws._viewport.hidden === true }
+                : null,
         });
     }
     res.json({ ok: true, count: devices.length, devices });
@@ -1157,6 +1165,10 @@ function handleInput(session, d, ws) {
                 // instead of the text impersonating local typing.
                 if (typeof d.via === 'string' && d.via) automations.announce(mgr, d.id, d.via.slice(0, 40));
                 const text = d.text || '';
+                // What comes back from this write is ECHO. Tell the batcher, so
+                // it stops holding this tab's output for the batching window
+                // while somebody is typing into it.
+                try { if (session._termBatcher) session._termBatcher.noteInput(d.id); } catch (_) {}
                 tab.write(text);
                 // Enter (CR/LF) is the only keystroke that plausibly ends
                 // a `cd` command — poll the shell's cwd on a short delay
@@ -1173,7 +1185,10 @@ function handleInput(session, d, ws) {
             // describes all of them — including tabs this client has never
             // opened, which is how a background agent used to sit at the 120x32
             // spawn size until you happened to visit it.
-            const vp = termGeometry.normalizeViewport(d.cols, d.rows);
+            // `hidden` is the client telling us it is not on screen. A viewer
+            // nobody is looking at must not be the one that decides the grid —
+            // see termGeometry.js. Absent from an older client = visible.
+            const vp = termGeometry.normalizeViewport(d.cols, d.rows, d.hidden === true);
             if (ws && vp) ws._viewport = vp;
             syncTabGeometry(session, d.id);
             break;

--- a/server/src/termBatch.js
+++ b/server/src/termBatch.js
@@ -30,6 +30,13 @@
  * Set either to 0 to flush on the next tick instead, which still merges
  * everything node delivered in the same poll phase.
  *
+ * ECHO is the exception to all of it. For 300ms after a key reaches a tab
+ * (SOA_TERM_ECHO_MS), that tab's output is the characters appearing under
+ * somebody's cursor, and a 12ms hold on a keystroke is felt in a way that a
+ * 12ms hold on a stream never is — so during that window the active tab flushes
+ * on the next tick. Typing is bounded by how fast a person types, so this costs
+ * a handful of extra frames per second and nothing else.
+ *
  * Compatibility is per socket, never global: a client opts in by sending
  * INPUT_KIND.CLIENT_CAPS with `{termBatch:true}`. Anything that has not opted
  * in — a tab still running the previous bundle, the read-only share viewers —
@@ -44,6 +51,9 @@ const envMs = (name, fallback) => {
 };
 const BATCH_MS = envMs('SOA_TERM_BATCH_MS', 12);
 const BATCH_BG_MS = envMs('SOA_TERM_BATCH_BG_MS', 100);
+// How long after a keystroke a tab's output is treated as echo and flushed on
+// the next tick instead of waiting out the batching window.
+const ECHO_WINDOW_MS = envMs('SOA_TERM_ECHO_MS', 300);
 
 class TermBatcher {
     /**
@@ -66,6 +76,29 @@ class TermBatcher {
         this._timer = null;
         this._immediate = null;
         this._lastBgFlush = 0;
+        this._typedAt = new Map();   // tabId -> when that tab last received input
+    }
+
+    /**
+     * Somebody typed into this tab. For a short window after that, its output is
+     * ECHO — the characters appearing under the cursor of whoever is watching —
+     * and holding echo for a batching window is the one delay in this file that
+     * is felt directly. 12ms is nothing against a stream and everything against
+     * a keystroke, so during the window the tab flushes on the next tick.
+     */
+    noteInput(tabId) {
+        if (tabId != null) this._typedAt.set(tabId, this._now());
+        // The map only ever holds tabs someone is typing in; still, don't let a
+        // long-lived session accumulate an entry per tab that ever saw a key.
+        if (this._typedAt.size > 64) {
+            const cutoff = this._now() - ECHO_WINDOW_MS;
+            for (const [id, at] of this._typedAt) if (at < cutoff) this._typedAt.delete(id);
+        }
+    }
+
+    _isEcho(tabId) {
+        const at = this._typedAt.get(tabId);
+        return at != null && (this._now() - at) < ECHO_WINDOW_MS;
     }
 
     /** Queue one tab's output. Ordering within a tab is preserved. */
@@ -74,7 +107,8 @@ class TermBatcher {
         const q = this._pending.get(tabId);
         if (q) q.push(data);
         else this._pending.set(tabId, [data]);
-        this._arm(tabId === this._activeTab() ? this._delayMs : this._bgDelayMs);
+        if (tabId === this._activeTab()) this._arm(this._isEcho(tabId) ? 0 : this._delayMs);
+        else this._arm(this._bgDelayMs);
     }
 
     // Wake no later than the soonest thing waiting needs. A background chunk

--- a/server/src/termGeometry.js
+++ b/server/src/termGeometry.js
@@ -23,6 +23,18 @@
  * mobile client is a passive viewer — it adopts the server's `cols` and shrinks
  * its own font to fit), so attaching a phone never narrows the desktop.
  *
+ * The minimum is taken over the viewers that are ACTUALLY LOOKING. A dashboard
+ * in a background browser tab, a second window left open on another desktop, an
+ * automation browser parked on the page — each of them declares a viewport, and
+ * under a plain minimum the narrowest of them decided the grid for the window
+ * you are reading, which shows up as a wide black strip down the right of a
+ * terminal that has room for another sixty columns. tmux has the same rule and
+ * the same answer: a detached client does not size the session. A hidden viewer
+ * is detached, so it is skipped — and it re-asserts the moment it comes back to
+ * the front, because then it really can be clipped. If NOBODY is visible the
+ * whole set counts again, so a fully-backgrounded session keeps a sane grid
+ * instead of falling back to a guess.
+ *
  * Two rules keep it from going stale, which was the other half of the bug:
  *
  *   - a viewport belongs to the SOCKET, not to a tab. Every tab in a session
@@ -36,13 +48,18 @@
 const MIN_COLS = 2;
 const MIN_ROWS = 2;
 
-/** Normalise a client-declared viewport, or null if it isn't usable. */
-function normalizeViewport(cols, rows) {
+/**
+ * Normalise a client-declared viewport, or null if it isn't usable.
+ * `hidden` is the client's own report that its page is not on screen; an old
+ * client that never sends it is treated as visible, which is the behaviour it
+ * has always had.
+ */
+function normalizeViewport(cols, rows, hidden) {
     const c = Math.trunc(Number(cols));
     const r = Math.trunc(Number(rows));
     if (!Number.isFinite(c) || !Number.isFinite(r)) return null;
     if (c < MIN_COLS || r < MIN_ROWS) return null;
-    return { cols: c, rows: r };
+    return { cols: c, rows: r, hidden: hidden === true };
 }
 
 /**
@@ -50,15 +67,20 @@ function normalizeViewport(cols, rows) {
  * `sockets` is any iterable of ws-like objects carrying `_viewport`.
  */
 function liveViewports(sockets) {
-    const out = [];
+    const all = [];
+    const visible = [];
     for (const ws of sockets || []) {
         if (!ws || ws.readyState !== 1 /* OPEN */) continue;
         const vp = ws._viewport;
         if (!vp) continue;
-        const norm = normalizeViewport(vp.cols, vp.rows);
-        if (norm) out.push(norm);
+        const norm = normalizeViewport(vp.cols, vp.rows, vp.hidden);
+        if (!norm) continue;
+        all.push(norm);
+        if (!norm.hidden) visible.push(norm);
     }
-    return out;
+    // Someone is looking: only they get a vote. Nobody is: everyone does, so a
+    // session whose windows are all in the background still has a real grid.
+    return visible.length ? visible : all;
 }
 
 /**

--- a/server/test/termBatch.test.js
+++ b/server/test/termBatch.test.js
@@ -184,3 +184,40 @@ test('destroy flushes background tabs too', () => {
     assert.equal(ws.frames.length, 1);
     assert.equal(ws.frames[0].d.items[0].data, 'would have waited five seconds');
 });
+
+test('a tab someone is typing into flushes on the next tick, not after the window', async () => {
+    // The batching window is what makes twenty-two streaming agents affordable,
+    // and it is also the one delay a person feels directly — it sits between the
+    // key they pressed and the character appearing. Echo opts out of it.
+    let clock = 0;
+    const ws = batching();
+    const b = new TermBatcher({
+        sockets: () => [ws], activeTab: () => 1,
+        delayMs: 25, bgDelayMs: 100, now: () => clock,
+    });
+
+    b.noteInput(1);
+    b.push(1, 'x');
+    await tick();
+    assert.equal(ws.frames.length, 1, 'echo went out without waiting for the window');
+
+    // Once the window since the keystroke has passed, the same tab is an
+    // ordinary stream again and pays the ordinary batching delay.
+    clock += 5000;
+    b.push(1, 'more output');
+    await tick();
+    assert.equal(ws.frames.length, 1, 'a stream still waits its turn');
+});
+
+test('typing in one tab does not un-batch the other twenty-one', async () => {
+    let clock = 0;
+    const ws = batching();
+    const b = new TermBatcher({
+        sockets: () => [ws], activeTab: () => 1,
+        delayMs: 25, bgDelayMs: 100, now: () => clock,
+    });
+    b.noteInput(1);
+    b.push(2, 'background chatter');
+    await tick();
+    assert.equal(ws.frames.length, 0, 'a background tab keeps its long window');
+});

--- a/server/test/termGeometry.test.js
+++ b/server/test/termGeometry.test.js
@@ -2,12 +2,14 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const { normalizeViewport, liveViewports, agreedSize } = require('../src/termGeometry');
 
-const sock = (cols, rows, readyState = 1) => ({ readyState, _viewport: cols == null ? null : { cols, rows } });
+const sock = (cols, rows, readyState = 1, hidden = false) =>
+    ({ readyState, _viewport: cols == null ? null : { cols, rows, hidden } });
 
 test('normalizeViewport rejects anything a terminal cannot be', () => {
-    assert.deepEqual(normalizeViewport(115, 53), { cols: 115, rows: 53 });
-    assert.deepEqual(normalizeViewport('115', '53'), { cols: 115, rows: 53 });
-    assert.deepEqual(normalizeViewport(115.9, 53.9), { cols: 115, rows: 53 });
+    assert.deepEqual(normalizeViewport(115, 53), { cols: 115, rows: 53, hidden: false });
+    assert.deepEqual(normalizeViewport('115', '53'), { cols: 115, rows: 53, hidden: false });
+    assert.deepEqual(normalizeViewport(115.9, 53.9), { cols: 115, rows: 53, hidden: false });
+    assert.deepEqual(normalizeViewport(115, 53, true), { cols: 115, rows: 53, hidden: true });
     assert.equal(normalizeViewport(1, 53), null);
     assert.equal(normalizeViewport(115, 1), null);
     assert.equal(normalizeViewport(NaN, 53), null);
@@ -22,7 +24,7 @@ test('liveViewports ignores closed sockets and sockets that never declared', () 
         null,
         sock(100, 40),
     ]);
-    assert.deepEqual(vps, [{ cols: 115, rows: 53 }, { cols: 100, rows: 40 }]);
+    assert.deepEqual(vps, [{ cols: 115, rows: 53, hidden: false }, { cols: 100, rows: 40, hidden: false }]);
 });
 
 test('the smallest attached viewer defines the grid, per axis', () => {
@@ -48,4 +50,27 @@ test('a departing viewer stops constraining the grid', () => {
     assert.deepEqual(agreedSize(liveViewports([wide, narrow])), { cols: 100, rows: 40 });
     narrow.readyState = 3;   // the narrow window closes
     assert.deepEqual(agreedSize(liveViewports([wide, narrow])), { cols: 134, rows: 61 });
+});
+
+test('a viewer nobody is looking at does not decide the grid', () => {
+    // The regression this exists to prevent: a dashboard left open in a
+    // background browser tab (or an automation browser parked on the page) is
+    // narrower than the window you are reading, and under a plain minimum it
+    // decided the grid — a wide black strip down the right of a terminal with
+    // room for sixty more columns.
+    const looking = sock(168, 46);
+    const background = sock(105, 40, 1, true);
+    assert.deepEqual(agreedSize(liveViewports([looking, background])), { cols: 168, rows: 46 });
+    // It gets its vote back the moment it is on screen, because then it really
+    // can be clipped.
+    background._viewport.hidden = false;
+    assert.deepEqual(agreedSize(liveViewports([looking, background])), { cols: 105, rows: 40 });
+});
+
+test('when every viewer is hidden the whole set still counts', () => {
+    // Otherwise a session whose windows are all in the background would have
+    // no declared viewport at all and fall back to a guess.
+    const a = sock(168, 46, 1, true);
+    const b = sock(105, 40, 1, true);
+    assert.deepEqual(agreedSize(liveViewports([a, b])), { cols: 105, rows: 40 });
 });

--- a/web/public/assets/app.js
+++ b/web/public/assets/app.js
@@ -147,6 +147,16 @@ function wireVersion() {
 }
 
 const $  = sel => document.querySelector(sel);
+// Is this page actually on screen? A dashboard in a background browser tab or
+// on another desktop is still a live socket with a declared viewport, and the
+// daemon sizes each PTY to the SMALLEST attached viewer — so a narrow window
+// left open somewhere else was deciding the grid for the window you are reading
+// and leaving a black strip down its right. We report the state with every
+// measurement; the daemon skips viewers that are not looking.
+const docHidden = () => {
+    try { return document.visibilityState === 'hidden'; } catch (_) { return false; }
+};
+
 const el = (tag, props = {}, children = []) => {
     const n = document.createElement(tag);
     for (const [k, v] of Object.entries(props)) {
@@ -264,7 +274,9 @@ class TabRuntime {
         try { this.term.onRender(repaint); } catch (_) {}
         try { this.term.onScroll(repaint); } catch (_) {}
         const vp = this.term.element && this.term.element.querySelector('.xterm-viewport');
-        if (vp) vp.addEventListener('scroll', repaint, { passive: true });
+        this._vp = vp || null;
+        this._screenEl = this.term.element && this.term.element.querySelector('.xterm-screen');
+        if (vp) vp.addEventListener('scroll', () => { this._syncSubRow(); repaint(); }, { passive: true });
         if (this._onData) this.term.onData(d => this._onData && this._onData(d));
         if (this._onResize) this.term.onResize(({ cols, rows }) => this._onResize && this._onResize(cols, rows));
         if (this._onTitle) this.term.onTitleChange(t => this._onTitle && this._onTitle(t));
@@ -332,12 +344,29 @@ class TabRuntime {
             return;
         }
         this._wq.push(data);
+        const t = performance.now();
+        const scrolling = t - (window.__soaLastScroll || 0) < 250;
+        // ECHO GOES NOW. Everything else in this file is a good reason to wait a
+        // frame; the character you just typed is not. Waiting for rAF is only
+        // ~16ms when the page is idle, but rAF is exactly what a long task
+        // delays — a widget re-render, a tile sweep, a status poll — so the
+        // keystroke you are watching for inherits the worst frame on the page
+        // instead of the average one. When a key went down in the last 300ms we
+        // parse the chunk synchronously and let xterm schedule its own paint.
+        //
+        // The rate limit is what keeps this from undoing the batching it sits
+        // in front of: a burst of output arriving while you type still collapses
+        // into one write per ~8ms, which is under a frame either way.
+        if (!scrolling && t - (window.__soaLastKey || 0) < 300 && t - (this._lastSync || 0) > 8) {
+            this._lastSync = t;
+            this._flushWrites();
+            return;
+        }
         if (this._wRaf || this._wTimer) return;
         // SCROLLING defers a write; typing must not. The two used to share one
         // interaction stamp, so every keystroke armed the 50ms path and echo
         // came back a beat late — the batching meant to protect a gesture was
         // taxing the thing you notice most.
-        const scrolling = performance.now() - (window.__soaLastScroll || 0) < 250;
         if (scrolling) this._wTimer = setTimeout(() => this._flushWrites(), TabRuntime.WRITE_BUSY_MS);
         // Always arm a timer alongside the frame callback. requestAnimationFrame
         // does not fire in a hidden or fully occluded window, and without this a
@@ -431,6 +460,77 @@ class TabRuntime {
         if (this._resetPending) { data = '\x18\x1bc' + data; this._resetPending = false; }
         this.term.write(data);
         return true;
+    }
+
+    // ── Sub-row scrolling ───────────────────────────────────────────────
+    //
+    // xterm scrolls in whole ROWS. The viewport element scrolls natively (which
+    // is what buys the trackpad momentum), but the grid underneath is redrawn
+    // only at `Math.round(scrollTop / cellHeight)` — so a gesture that moves the
+    // scroll position smoothly moves the TEXT in ~18px jumps, each landing up to
+    // half a row away from where your fingers are. That mismatch is the whole of
+    // what reads as "steppy", and during a fast flick the row the renderer is
+    // still catching up to is the stale frame you see.
+    //
+    // The fix is not to fight the quantisation but to pay back the remainder:
+    // translate the painted screen by the sub-row offset the emulator threw
+    // away. It is one composited transform — no reflow, no repaint, no extra
+    // render — so the glyphs now track the gesture pixel for pixel while xterm
+    // goes on drawing whole rows at its own pace.
+    //
+    // The bands ride the same transform, or they would drift off the text they
+    // are marking by up to half a row.
+    _cellHeight() {
+        try {
+            const dims = this.term._core && this.term._core._renderService
+                && this.term._core._renderService.dimensions;
+            const h = dims && dims.css && dims.css.cell && dims.css.cell.height;
+            if (h > 1) return h;
+            const scr = this._screenEl;
+            const r = scr && scr.getBoundingClientRect().height;
+            return r && this.term.rows ? r / this.term.rows : 0;
+        } catch (_) { return 0; }
+    }
+
+    _setSubRow(px) {
+        const t = px ? `translate3d(0, ${px.toFixed(2)}px, 0)` : '';
+        if (this._screenEl && this._screenEl.style.transform !== t) this._screenEl.style.transform = t;
+        if (this.bandsEl && this.bandsEl.style.transform !== t) this.bandsEl.style.transform = t;
+    }
+
+    _syncSubRow() {
+        const vp = this._vp;
+        if (!vp) return;
+        const cellH = this._cellHeight();
+        if (!(cellH > 1)) return;
+        let off;
+        try { off = vp.scrollTop - this.term.buffer.active.viewportY * cellH; } catch (_) { return; }
+        // A remainder bigger than a row means the emulator has not caught up
+        // yet (a write moved the buffer under us). Don't drag the screen across
+        // the viewport chasing it; let the next render settle it.
+        if (!(Math.abs(off) <= cellH)) { this._setSubRow(0); return; }
+        this._setSubRow(Math.abs(off) < 0.5 ? 0 : -off);
+        // At REST the remainder must go away, or the grid sits permanently up to
+        // half a row out of its own frame and the bottom edge shows a sliver of
+        // background. Snapping the scroll position to the row it is already
+        // rendering is a 1-9px correction nobody can see mid-gesture, and it
+        // lands the terminal exactly on its grid once the flick stops.
+        if (this._snapTimer) clearTimeout(this._snapTimer);
+        this._snapTimer = setTimeout(() => { this._snapTimer = null; this._snapToRow(); }, 140);
+    }
+
+    _snapToRow() {
+        const vp = this._vp;
+        if (!vp) return;
+        const cellH = this._cellHeight();
+        if (!(cellH > 1)) { this._setSubRow(0); return; }
+        try {
+            const want = this.term.buffer.active.viewportY * cellH;
+            // Setting scrollTop re-enters this scroll handler; it computes a
+            // remainder of zero and stops there, so there is no loop.
+            if (Math.abs(vp.scrollTop - want) > 0.5) vp.scrollTop = want;
+        } catch (_) {}
+        this._setSubRow(0);
     }
 
     // ── Transcript banding ──────────────────────────────────────────────
@@ -1132,6 +1232,7 @@ class Shell {
             if (saved != null) ctxOff = saved === '1';
         } catch (_) {}
         stageEl.classList.toggle('no-context', ctxOff);
+        this._watchVisibility();
         const ctxPull = $('#ctx-pull');
         const setContextOff = (off) => {
             stageEl.classList.toggle('no-context', off);
@@ -1248,9 +1349,13 @@ class Shell {
         // deferring the echo of what you are typing is not, and one stamp for
         // both could not tell them apart.
         const bumpScroll = () => { bump(); window.__soaLastScroll = performance.now(); };
+        // A third stamp, keys only. TabRuntime.write reads it to flush echo
+        // synchronously instead of waiting for a frame that a long task
+        // elsewhere on the page may be sitting on.
+        const bumpKey = () => { bump(); window.__soaLastKey = performance.now(); };
         window.addEventListener('wheel', bumpScroll, { passive: true, capture: true });
         window.addEventListener('touchmove', bumpScroll, { passive: true, capture: true });
-        window.addEventListener('keydown', bump, { capture: true });
+        window.addEventListener('keydown', bumpKey, { capture: true });
 
         window.addEventListener('resize', () => this._fitActive());
         window.addEventListener('orientationchange', () => setTimeout(() => this._fitActive(), 150));
@@ -1674,7 +1779,7 @@ class Shell {
         this.termsEl.appendChild(rt.container);
         rt.attach(
             data => this.bridge.input(INPUT_KIND.TERM_KEYS, { id, text: data }),
-            (cols, rows) => this.bridge.input(INPUT_KIND.TERM_RESIZE, { id, cols, rows }),
+            (cols, rows) => this.bridge.input(INPUT_KIND.TERM_RESIZE, { id, cols, rows, hidden: docHidden() }),
             t => this.bridge.input(INPUT_KIND.SET_TITLE, { id, title: t }),
         );
         this.tabs.set(id, rt);
@@ -3481,6 +3586,28 @@ class Shell {
         this._broadcastSizeSoon();
     }
 
+    // Coming back to the front is a real geometry event: while this window was
+    // hidden the daemon ignored its viewport, so the PTY may now be wider than
+    // this emulator can draw — which is the wrapping corruption, not a cosmetic
+    // gutter. Re-declare the moment we are visible again, and release the claim
+    // the moment we are not.
+    _watchVisibility() {
+        if (this._visWatched) return;
+        this._visWatched = true;
+        document.addEventListener('visibilitychange', () => {
+            const rt = this.tabs.get(this.activeId);
+            if (!rt || !rt.term) return;
+            const { cols, rows } = rt.term;
+            if (!(cols > 1 && rows > 1)) return;
+            // Force the send: the size has NOT changed, only who is looking, and
+            // _broadcastSize dedupes on the size alone.
+            if (this._sentSize) this._sentSize.delete(this.activeId);
+            this.bridge.input(INPUT_KIND.TERM_RESIZE,
+                { id: this.activeId, cols, rows, hidden: docHidden() });
+            if (!docHidden()) this._fitActive();
+        });
+    }
+
     // Every tab shares ONE terminal area, so the active tab's measurement is
     // the right size for all of them — but only the active tab has a painted
     // xterm to measure, so a tab you have not visited since it was spawned (or
@@ -3509,7 +3636,7 @@ class Shell {
             // added, which is exactly the reported shape.
             if (known && id !== this.activeId) continue;
             this._sentSize.set(id, key);
-            this.bridge.input(INPUT_KIND.TERM_RESIZE, { id, cols, rows });
+            this.bridge.input(INPUT_KIND.TERM_RESIZE, { id, cols, rows, hidden: docHidden() });
         }
     }
 

--- a/web/public/assets/styles.css
+++ b/web/public/assets/styles.css
@@ -301,9 +301,16 @@ html, body {
   animation: soa-breathe-bright 2.4s ease-in-out infinite;
 }
 .tab[data-agent="attention"].active { animation: soa-breathe-bright 1.1s ease-in-out infinite; }
+/* The breathing states animate OPACITY and nothing else. The glow used to be
+   part of the keyframe (`text-shadow` at 50%), which meant every pulsing tab
+   repainted its text on every frame, forever — main-thread work competing with
+   the terminal for the whole time any agent was waiting on you. The shadow is
+   now a constant on the element, so the same look costs one composited layer
+   per tab instead of a repaint. */
+.tab[data-agent="attention"], .tab[data-agent="delegating"] { text-shadow: 0 0 8px currentColor; }
 @keyframes soa-breathe {
   0%, 100% { opacity: 0.55; }
-  50%      { opacity: 1; text-shadow: 0 0 8px currentColor; }
+  50%      { opacity: 1; }
 }
 @keyframes soa-breathe-bright {
   0%, 100% { filter: brightness(0.8); }
@@ -312,6 +319,12 @@ html, body {
 @keyframes soa-agent-pulse {
   0%, 100% { opacity: 1; }
   50%      { opacity: 0.55; }
+}
+/* Twenty-two tabs breathing at four different rates is a lot of motion to sit
+   in front of all day. Anyone who has asked the OS for less of it gets the
+   colour and the state, held steady. */
+@media (prefers-reduced-motion: reduce) {
+  .tab[data-agent], .tab[data-agent] .ctx-bar { animation: none !important; }
 }
 .tab[data-agent="attention"] .ctx-bar { animation: soa-agent-pulse 1.1s ease-in-out infinite; }
 .tab[data-agent="delegating"] .ctx-bar { animation: soa-agent-pulse 2.4s ease-in-out infinite; }


### PR DESCRIPTION
Three reported symptoms, three points in the same pipeline.

**Input delay.** Echo waited for a frame at both ends — the daemon's 12ms batching window, then the client's next `requestAnimationFrame`. rAF is what a long task delays, so the keystroke inherits the page's worst frame. For 300ms after a key reaches a tab its output is echo: the daemon flushes on the next tick, the client parses synchronously, rate-limited to one write per 8ms so a burst still collapses.

**Steppy scrolling and stale frames.** xterm redraws at `round(scrollTop / cellHeight)`, so smooth scroll moved the text in whole-row jumps. The sub-row remainder is paid back as one composited transform on the screen and the bands, then snapped to the row at rest.

**The right-hand black strip.** The PTY is sized to the smallest attached viewer — correct, but it was the smallest of *all* viewers, so a background dashboard tab decided the grid for the window you were reading. Hidden viewers no longer vote, and re-assert when they come to the front. `/api/devices` now reports each viewer's declared grid.

Also: tab breathing animated `text-shadow` (a repaint per frame per pulsing tab, forever). Now opacity-only with a constant glow, and `prefers-reduced-motion` holds it steady.

Tests: 213 pass, including new coverage for the echo path and for a hidden viewer not constraining the grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)