### PR TITLE
fix(ctx,timemachine): a tab you can see, a prompt you can read, a snapshot that has the fleet in it

### DIFF
--- a/server/src/tabApi.js
+++ b/server/src/tabApi.js
@@ -82,6 +82,39 @@ function mount(app, requireAuthed, sessions) {
         res.json({ ok: true, tabs });
     });
 
+    // Every tab's scrollback, in one call, straight from the daemon's ring.
+    //
+    // This exists for the Time Machine, whose capture used to read the BROWSER's
+    // xterm buffers. That is the wrong source three ways over: a tab you have
+    // never opened in this window has no xterm buffer at all (its bytes are
+    // still queued as pending replay), the buffers that do exist are capped at
+    // 1000 lines to keep twenty-odd tabs inside the page's memory budget, and
+    // reading them back through translateToString throws away every colour and
+    // every escape. The daemon holds 256 KB of RAW bytes per tab for ALL tabs,
+    // live or backgrounded, and persists them across its own restarts — so a
+    // snapshot taken from here captures the fleet, not the window.
+    //
+    // `?bytes=` trims each tab to its last N bytes (from a line boundary, so a
+    // trimmed dump never opens mid-escape-sequence and paints the rest of the
+    // replay the wrong colour).
+    router.get('/api/scrollback', requireAuthed, (req, res) => {
+        const s = resolveSession(req);
+        if (!s) return res.json({ ok: true, tabs: [] });
+        const cap = Math.max(0, Math.min(1024 * 1024, parseInt(req.query.bytes, 10) || 0));
+        const tabs = s.tabMgr.list().map(t => {
+            const tab = s.tabMgr.get(t.id);
+            let data = '';
+            try { data = s.tabMgr.scrollback(t.id) || ''; } catch (_) { data = ''; }
+            if (cap && data.length > cap) {
+                const cut = data.length - cap;
+                const nl = data.indexOf('\n', cut);
+                data = data.slice(nl >= 0 && nl - cut < 4096 ? nl + 1 : cut);
+            }
+            return { id: t.id, title: t.title, cwd: tab ? tab.cwd : null, exited: t.exited, data };
+        });
+        res.json({ ok: true, tabs });
+    });
+
     router.post('/api/tabs', requireAuthed, (req, res) => {
         const s = resolveSession(req);
         if (!s) return res.status(503).json({ ok: false, error: 'no active session' });

--- a/web/public/assets/contextPanel.js
+++ b/web/public/assets/contextPanel.js
@@ -304,22 +304,64 @@ class ContextCanvas {
         this._renderSteps();
     }
 
+    // A turn is keyed by when it was sent, not by its position: the thread grows
+    // from the bottom, so an index would move every prompt's identity down one
+    // on the next poll and an expanded turn would collapse itself.
+    _turnKey(p, i) { return String(p.at || '') + ':' + i + ':' + (p.text || '').length; }
+
     _renderThread(prompts) {
         if (!prompts.length) {
             this._thread.replaceChildren(el('p', { class: 'ctx-muted', text: 'no prompts recorded for this workspace yet' }));
             return;
         }
+        if (!this._open) this._open = new Set();
         const last = prompts.length - 1;
-        this._thread.replaceChildren(...prompts.map((p, i) => el('article', {
-            class: 'ctx-turn' + (i === last ? ' latest' : ''),
-        }, [
-            el('div', { class: 'ctx-turn-m' }, [
-                el('span', { class: 'ctx-turn-n', text: String(i + 1) }),
-                el('span', { class: 'ctx-turn-t', text: ago(p.at) }),
-            ]),
-            el('p', { class: 'ctx-turn-x', text: p.text }),
-        ])));
+        this._thread.replaceChildren(...prompts.map((p, i) => {
+            const key = this._turnKey(p, i);
+            const more = el('button', {
+                class: 'ctx-turn-more', type: 'button', hidden: '',
+                title: 'Show the whole prompt', 'aria-label': 'Show the whole prompt',
+            });
+            const node = el('article', {
+                class: 'ctx-turn' + (i === last ? ' latest' : '') + (this._open.has(key) ? ' open' : ''),
+            }, [
+                el('div', { class: 'ctx-turn-m' }, [
+                    el('span', { class: 'ctx-turn-n', text: String(i + 1) }),
+                    el('span', { class: 'ctx-turn-t', text: ago(p.at) }),
+                    more,
+                ]),
+                el('p', { class: 'ctx-turn-x', text: p.text }),
+            ]);
+            node.dataset.key = key;
+            more.addEventListener('click', () => {
+                const open = node.classList.toggle('open');
+                if (open) this._open.add(key); else this._open.delete(key);
+                const label = open ? 'Collapse this prompt' : 'Show the whole prompt';
+                more.title = label;
+                more.setAttribute('aria-label', label);
+                if (!open) this._markClipped();
+            });
+            return node;
+        }));
+        // Which turns are actually CUT can only be known once they are laid out,
+        // and asking costs a forced layout — so ask once per render, after the
+        // subtree is in place, and only for turns that are not already open.
+        this._markClipped();
         if (this._pinned) this._thread.scrollTop = this._thread.scrollHeight;
+    }
+
+    // Show the toggle only where there is something behind the fade. A prompt
+    // that fits gets no affordance at all, which is why the column still reads
+    // as a thread and not as a list of controls.
+    _markClipped() {
+        for (const node of this._thread.querySelectorAll('.ctx-turn')) {
+            const x = node.querySelector('.ctx-turn-x');
+            const more = node.querySelector('.ctx-turn-more');
+            if (!x || !more) continue;
+            const cut = !node.classList.contains('open') && x.scrollHeight > x.clientHeight + 2;
+            node.classList.toggle('clipped', cut);
+            more.hidden = !(cut || node.classList.contains('open'));
+        }
     }
 
     _renderFacts(w, d) {

--- a/web/public/assets/liquid.css
+++ b/web/public/assets/liquid.css
@@ -588,6 +588,8 @@
 }
 [data-ui="liquid"] :is(.ctx-art-t, .ctx-step-x) { font-family: var(--font-display); }
 [data-ui="liquid"] .ctx-step-add { font-family: var(--font-display); border-radius: var(--lq-r-xs); }
+/* Glass at rest too — the tab is a sliver of the panel that got left out. */
+[data-ui="liquid"] .ctx-pull { background-color: var(--lq-glass); }
 [data-ui="liquid"] .ctx-pull::before { background: rgba(255, 255, 255, 0.35); }
 [data-ui="liquid"] .ctx-pull:hover {
   background-color: var(--lq-glass-2); box-shadow: var(--lq-rim);

--- a/web/public/assets/minimal.css
+++ b/web/public/assets/minimal.css
@@ -533,7 +533,9 @@
 [data-ui="minimal"] .ctx-turn.latest { background: rgba(var(--m-ink-rgb), 0.045); }
 [data-ui="minimal"] :is(.ctx-art-t, .ctx-step-x) { font-family: var(--font-display); color: var(--soa-fg); }
 [data-ui="minimal"] .ctx-step-add { font-family: var(--font-display); text-transform: lowercase; }
-/* The pull tab is furniture on paper: a hairline grip, no glow. */
+/* The pull tab is furniture on paper: a card-coloured tab, a hairline grip,
+   no glow. */
+[data-ui="minimal"] .ctx-pull { background-color: var(--m-card); }
 [data-ui="minimal"] .ctx-pull::before { background: rgba(var(--m-ink-rgb), 0.28); }
 [data-ui="minimal"] .ctx-pull:hover { box-shadow: none; background-color: var(--m-card); }
 

--- a/web/public/assets/sidebar.css
+++ b/web/public/assets/sidebar.css
@@ -448,20 +448,21 @@
    handle rides the panel's outer border and slides to the viewport edge when
    the panel closes — it never disappears, only the chevron flips.
 
-   At REST the tab is only a grip mark on that border, never a filled slab:
-   the terminal deliberately runs edge-to-edge (`.terms .term` takes no right
-   padding so no column is wasted), so an opaque 15px block parked mid-height
-   reads as a black square dropped on the last two characters of every line it
-   crosses. Hover, focus or a finger promotes the same button to the full
-   labelled tab — the affordance is there when you reach for it and out of the
-   way while you are reading. */
+   At REST it is a small TAB, not an invisible grip: a 15px slab in the panel's
+   own colour, carrying the chevron, parked at mid-height. The earlier resting
+   state was a 3px hairline at half opacity, which kept the terminal pristine
+   and cost the control its discoverability — nothing on screen said the canvas
+   could come back. The slab is narrow, panel-coloured and it is the panel's
+   border it sits on, so it crosses the terminal only in the CLOSED state, which
+   is exactly when you need to find it. Hover, focus or a finger adds the CTX
+   label and lights the tab up. */
 .ctx-pull {
     position: absolute; top: 50%; right: var(--soa-ctx-w, 256px);
     transform: translateY(-50%);
     width: 15px; min-height: 88px; padding: 11px 0 13px;
     display: flex; flex-direction: column; align-items: center; gap: 8px;
-    background-color: transparent;
-    border: 1px solid transparent; border-right: none;
+    background-color: var(--soa-bg-panel);
+    border: 1px solid var(--soa-line); border-right: none;
     border-radius: 4px 0 0 4px;
     font-family: var(--font-mono); font-size: 9px; letter-spacing: 0.2em;
     color: var(--soa-accent-dim); cursor: pointer; z-index: 7;
@@ -469,28 +470,32 @@
                 border-color 160ms ease, box-shadow 160ms ease;
 }
 .stage.no-context .ctx-pull { right: 0; }
-/* The resting mark: the panel's own hairline border, thickened where you grab it. */
+/* The grip: an accent rail down the seam, so the tab reads as something you
+   pull rather than a button that happens to be tall. */
 .ctx-pull::before {
     content: ''; position: absolute; right: 0; top: 12px; bottom: 12px;
     width: 3px; border-radius: 2px 0 0 2px;
-    background: var(--soa-accent-dim); opacity: 0.5;
+    background: var(--soa-accent-dim); opacity: 0.55;
     transition: opacity 160ms ease;
 }
-.ctx-pull > * { opacity: 0; transition: opacity 160ms ease; }
+/* The chevron is the tab's whole message at rest — it says which way the panel
+   will move. The CTX label is the second thing you need, and only once you have
+   reached for it, so it is the one that fades in. */
+.ctx-pull-chev { opacity: 0.85; transition: opacity 160ms ease; }
+.ctx-pull-label { opacity: 0; transition: opacity 160ms ease; }
 .ctx-pull:hover, .ctx-pull:focus-visible {
-    background-color: var(--soa-bg-panel);
     color: var(--soa-accent); border-color: var(--soa-accent-dim);
     box-shadow: -5px 0 16px rgba(var(--soa-accent-rgb), 0.14);
 }
-.ctx-pull:hover > *, .ctx-pull:focus-visible > * { opacity: 1; }
-.ctx-pull:hover::before, .ctx-pull:focus-visible::before { opacity: 0; }
-/* Nothing hovers on a touch dashboard, so the mark carries a little more
-   weight there and the tab fills in only while the finger is down. */
+.ctx-pull:hover .ctx-pull-chev, .ctx-pull:focus-visible .ctx-pull-chev,
+.ctx-pull:hover .ctx-pull-label, .ctx-pull:focus-visible .ctx-pull-label { opacity: 1; }
+.ctx-pull:hover::before, .ctx-pull:focus-visible::before { opacity: 1; }
+/* Nothing hovers on a touch dashboard, so the label comes in while the finger
+   is down instead. */
 @media (hover: none) {
-    .ctx-pull::before { width: 4px; opacity: 0.75; }
-    .ctx-pull:active { background-color: var(--soa-bg-panel); border-color: var(--soa-accent-dim); }
-    .ctx-pull:active > * { opacity: 1; }
-    .ctx-pull:active::before { opacity: 0; }
+    .ctx-pull::before { width: 4px; opacity: 0.8; }
+    .ctx-pull:active { border-color: var(--soa-accent-dim); }
+    .ctx-pull:active .ctx-pull-label { opacity: 1; }
 }
 .ctx-pull:focus-visible { outline: 1px solid var(--soa-accent); outline-offset: 1px; }
 /* The glyph points the way the panel will travel, so it reads as a direction
@@ -559,6 +564,29 @@
     max-height: 7.2em; overflow: hidden;
 }
 .ctx-turn.latest .ctx-turn-x { max-height: none; }
+/* A clipped prompt used to end mid-word with nothing to say it had been cut and
+   no way to see the rest — the panel was showing a prompt you could not read.
+   Every turn now opens to its full text. The fade marks the cut as deliberate,
+   and the toggle in the gutter is the way through it; the text itself is left
+   alone so selecting a run of prompts still copies cleanly. */
+.ctx-turn.clipped .ctx-turn-x {
+    -webkit-mask-image: linear-gradient(180deg, #000 70%, transparent 100%);
+            mask-image: linear-gradient(180deg, #000 70%, transparent 100%);
+}
+.ctx-turn.open .ctx-turn-x {
+    max-height: none;
+    -webkit-mask-image: none; mask-image: none;
+}
+.ctx-turn-more {
+    appearance: none; background: none; border: 0; padding: 2px 0 0;
+    font-family: var(--font-mono); font-size: 9px; line-height: 1;
+    color: var(--soa-accent-dim); opacity: 0.7; cursor: pointer;
+    transition: color 120ms ease, opacity 120ms ease;
+}
+.ctx-turn-more:hover { color: var(--soa-accent); opacity: 1; }
+.ctx-turn-more:focus-visible { outline: 1px solid var(--soa-accent); outline-offset: 1px; }
+.ctx-turn-more::before { content: '\002B'; }          /* + more to read */
+.ctx-turn.open .ctx-turn-more::before { content: '\2212'; }   /* − collapse */
 
 /* Every band gets enough default height to show its content instead of
    collapsing to one scrolling line. WORKSPACE has four facts and was showing

--- a/web/public/assets/timemachine.js
+++ b/web/public/assets/timemachine.js
@@ -26,27 +26,68 @@
  *
  * What we capture per snapshot:
  *   - viewMode, activeId, tab order
- *   - per tab: id, title, cwd, scrollback rendered from xterm's active buffer
+ *   - per tab: id, title, cwd, and its scrollback
  *   - settings JSON, language, per-tab ctx % and agent status
  *
+ * WHERE THE SCROLLBACK COMES FROM (v3) — this is what "it doesn't capture all
+ * the context" was. Capture used to read the browser's own xterm buffers, and
+ * that source is incomplete three separate ways:
+ *
+ *   - a tab this window has never ACTIVATED has no xterm buffer to read. Its
+ *     output is still sitting in TabRuntime._replayChunks waiting for a first
+ *     valid fit, so it dumped as an empty string and the snapshot recorded the
+ *     tab as having no history at all. On a 22-tab fleet where you work in
+ *     three of them, that is most of the fleet.
+ *   - the buffers that DO exist hold 1000 lines (deliberately: twenty-odd
+ *     5000-line buffers was crashing the page), so even a tab you live in was
+ *     captured up to its last thousand lines and no further.
+ *   - translateToString returns plain text, so every colour, every cursor move
+ *     and every escape was thrown away before it was ever written down. A
+ *     restore repainted a grey transcript of something that had been coloured.
+ *
+ * The daemon holds the real thing: a 256 KB ring of RAW bytes per tab, for
+ * EVERY tab, live or backgrounded or never once looked at, persisted across its
+ * own restarts. So capture asks it (GET /api/scrollback) and stores those bytes
+ * verbatim; the xterm dump survives only as the fallback for when the daemon
+ * cannot be reached, which is also the only case where it is all we have.
+ *
+ * HOW IT STAYS SMALL. Raw bytes for a whole fleet are ~20× what the old text
+ * dump was, and 60 snapshots of it would be hundreds of megabytes. But between
+ * two snapshots five minutes apart most tabs have emitted nothing, so the same
+ * bytes were being written 60 times over. Scrollback now lives in its own
+ * content-addressed store: a tab entry carries `sb`, the hash of its bytes, and
+ * the bytes are written once under that key. An unchanged tab costs a 16-byte
+ * string per snapshot. Blobs nothing references any more are collected when
+ * snapshots are pruned.
+ *
  * Why IndexedDB, not localStorage:
- *   60 snapshots × ~200 KB of scrollback each = ~12 MB. localStorage caps at
- *   5–10 MB and serializes synchronously on the main thread; IDB handles the
- *   size and stays off the render path.
+ *   localStorage caps at 5–10 MB and serializes synchronously on the main
+ *   thread; IDB handles the size and stays off the render path.
  *
  * Retention: hardcoded MAX_SNAPSHOTS = 60. Older entries are pruned on each
  * write so quota pressure can't build up over a long-lived session.
  */
 
 const DB_NAME = 'soa-web-tm';
-const DB_VERSION = 1;
+const DB_VERSION = 2;
 const STORE = 'snapshots';
+// Content-addressed scrollback. Keyed by hash, so a tab that has not emitted
+// anything since the last snapshot is stored once and referenced sixty times.
+const BLOBS = 'blobs';
 const MAX_SNAPSHOTS = 60;
 const INTERVAL_MS = 5 * 60 * 1000;
 const MAX_LINES_PER_TAB = 4096;
-// v2 adds per-tab cwd — the field that makes REBUILD possible. v1 snapshots stay
-// readable and restore in replay-only mode.
-const SCHEMA_VERSION = 2;
+// What we keep per tab when the daemon gives us its raw ring. Its own cap is
+// 256 KB; this is the same number, so we take everything it has.
+const MAX_BYTES_PER_TAB = 256 * 1024;
+// The daemon is on loopback. If it cannot answer in this long it is wedged, and
+// a snapshot must degrade to the local buffers rather than block the page.
+const FETCH_TIMEOUT_MS = 4000;
+// v2 adds per-tab cwd — the field that makes REBUILD possible. v3 moves the
+// scrollback into the blob store and keeps RAW bytes instead of stripped text.
+// v1 and v2 snapshots stay readable: their scrollback is inline, and restore
+// takes it from wherever it finds it.
+const SCHEMA_VERSION = 3;
 // A snapshot is worthless if writing it wedges the tab, so IDB work is bounded.
 const IDB_TIMEOUT_MS = 4000;
 // How long to wait for the daemon's reopened tabs to arrive over the WS snapshot.
@@ -77,6 +118,12 @@ function _open() {
             const db = req.result;
             if (!db.objectStoreNames.contains(STORE)) {
                 db.createObjectStore(STORE, { keyPath: 'ts' });
+            }
+            // Added in DB_VERSION 2. Existing snapshots keep their inline
+            // scrollback and are never rewritten — an upgrade must not be able
+            // to lose the history it is upgrading.
+            if (!db.objectStoreNames.contains(BLOBS)) {
+                db.createObjectStore(BLOBS, { keyPath: 'h' });
             }
         };
         req.onsuccess = () => { clearTimeout(timer); _db = req.result; resolve(_db); };
@@ -145,6 +192,92 @@ async function _prune() {
     all.sort((a, b) => a.ts - b.ts);
     const drop = all.length - MAX_SNAPSHOTS;
     for (let i = 0; i < drop; i++) await _delete(all[i].ts);
+    // Pruning is the only thing that can orphan a blob, so it is the only place
+    // that needs to collect them.
+    try { await _gcBlobs(); } catch (_) {}
+}
+
+// ── Content-addressed scrollback ────────────────────────────────────────────
+// FNV-1a over the string. Not a cryptographic hash and does not need to be:
+// the only question it answers is "are these the same bytes I already stored",
+// and the length is folded in so a collision has to match on both.
+function _hash(str) {
+    let h = 0x811c9dc5;
+    for (let i = 0; i < str.length; i++) {
+        h ^= str.charCodeAt(i);
+        h = (h + ((h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24))) >>> 0;
+    }
+    return h.toString(36) + '-' + str.length.toString(36);
+}
+
+function _blobTx(mode) {
+    return _open().then(db => db.transaction(BLOBS, mode).objectStore(BLOBS));
+}
+
+// Write the bytes only if this hash is not already on disk. The read costs one
+// index lookup; the write it avoids is a quarter of a megabyte.
+async function _putBlob(h, data) {
+    const store = await _blobTx('readwrite');
+    return new Promise((res, rej) => {
+        const get = store.get(h);
+        get.onsuccess = () => {
+            if (get.result) { res(false); return; }
+            const put = store.put({ h, data });
+            put.onsuccess = () => res(true);
+            put.onerror = () => rej(put.error);
+        };
+        get.onerror = () => rej(get.error);
+    });
+}
+
+async function _getBlob(h) {
+    const store = await _blobTx('readonly');
+    return new Promise((res) => {
+        const r = store.get(h);
+        r.onsuccess = () => res(r.result ? r.result.data : '');
+        r.onerror = () => res('');
+    });
+}
+
+// Drop every blob no surviving snapshot points at. Called after pruning, which
+// is the only moment a reference can disappear.
+async function _gcBlobs() {
+    const live = new Set();
+    for (const snap of await _all()) {
+        for (const t of snap.tabs || []) if (t && t.sb) live.add(t.sb);
+    }
+    const store = await _blobTx('readwrite');
+    await new Promise((res) => {
+        const r = store.getAllKeys();
+        r.onsuccess = () => {
+            for (const key of r.result || []) if (!live.has(key)) store.delete(key);
+            res();
+        };
+        r.onerror = () => res();
+    });
+}
+
+// ── The authoritative scrollback ────────────────────────────────────────────
+// Every tab's raw bytes from the daemon in one call. Returns null — not an
+// empty map — when it cannot be reached, so the caller can tell "the daemon
+// says these tabs are empty" apart from "there was no daemon to ask".
+async function _fetchFleetScrollback(shell) {
+    try {
+        const ctl = typeof AbortController !== 'undefined' ? new AbortController() : null;
+        const timer = ctl ? setTimeout(() => ctl.abort(), FETCH_TIMEOUT_MS) : null;
+        let r;
+        try {
+            r = await fetch(_api(shell, `/api/scrollback?bytes=${MAX_BYTES_PER_TAB}`), {
+                credentials: 'include', signal: ctl ? ctl.signal : undefined,
+            });
+        } finally { if (timer) clearTimeout(timer); }
+        if (!r || !r.ok) return null;
+        const j = await r.json();
+        if (!j || !j.ok || !Array.isArray(j.tabs)) return null;
+        const map = new Map();
+        for (const t of j.tabs) if (t && t.id != null) map.set(t.id, typeof t.data === 'string' ? t.data : '');
+        return map;
+    } catch (_) { return null; }
 }
 
 // Per-tab dump cache. A snapshot re-reads every tab's whole buffer, and on a
@@ -188,24 +321,39 @@ export async function snapshotNow(shell) {
     if (!shell) return null;
     const ts = Date.now();
     const tabs = [];
-    // Yield between tabs. Reading a buffer is ~1000 translateToString calls, and
-    // doing twenty-odd of those back to back is a single task long enough to
-    // freeze the page — which is what a snapshot every five minutes felt like.
-    // Broken up, no individual task is long enough to drop a frame.
+    // The fleet's real scrollback, asked for ONCE. null means the daemon could
+    // not be reached, and only then do we fall back to this window's buffers.
+    const fleet = await _fetchFleetScrollback(shell);
+    // Yield between tabs. Hashing and storing a quarter-megabyte per tab back to
+    // back is a single task long enough to freeze the page — which is what a
+    // snapshot every five minutes felt like. Broken up, no individual task is
+    // long enough to drop a frame.
     const breathe = () => new Promise(r => setTimeout(r, 0));
     let n = 0;
+    let fromDaemon = 0;
     for (const id of shell.order) {
         const rt = shell.tabs.get(id);
         if (!rt) continue;
         if (n++ > 0) await breathe();
-        tabs.push({
+        // The daemon's bytes win whenever it has them, INCLUDING when it says a
+        // tab is empty — it is the one that saw the output. The local buffer is
+        // for when there is nobody to ask.
+        let text = fleet && fleet.has(id) ? fleet.get(id) : null;
+        if (text == null) text = _dumpScrollback(rt);
+        else fromDaemon++;
+        const entry = {
             id,
             title: rt.title || `tab #${id}`,
             // The field that makes a rebuild possible. Without it a snapshot can
             // only ever repaint tabs that still exist.
             cwd: (shell._tabCwd && shell._tabCwd.get(id)) || null,
-            scrollback: _dumpScrollback(rt),
-        });
+        };
+        if (text) {
+            const h = _hash(text);
+            try { await _putBlob(h, text); entry.sb = h; }
+            catch (_) { entry.scrollback = text; }   // blob store unavailable: inline it
+        }
+        tabs.push(entry);
     }
     const ctxPct = {};
     for (const [id, p] of shell._ctxPct || []) ctxPct[id] = p;
@@ -230,7 +378,9 @@ export async function snapshotNow(shell) {
     try {
         await _putTolerant(snap);
         await _prune();
-        console.log(`[timemachine] saved snapshot at ${new Date(ts).toLocaleTimeString()} (${tabs.length} tabs, ${tabs.filter(t => t.cwd).length} with cwd)`);
+        console.log(`[timemachine] saved snapshot at ${new Date(ts).toLocaleTimeString()} `
+            + `(${tabs.length} tabs, ${tabs.filter(t => t.cwd).length} with cwd, `
+            + `${fromDaemon} from the daemon, ${tabs.filter(t => t.sb || t.scrollback).length} with scrollback)`);
     } catch (err) {
         console.warn('[timemachine] save failed', err);
         return null;
@@ -246,6 +396,10 @@ export async function listSnapshots() {
         tabCount: (s.tabs || []).length,
         // A snapshot can rebuild only the tabs whose cwd it recorded.
         cwdCount: (s.tabs || []).filter(t => t && t.cwd).length,
+        // ...and it can only REPLAY the tabs whose scrollback it actually got.
+        // Surfacing this is the point: a snapshot that captured three tabs out
+        // of twenty-two should say so on the row, not at restore time.
+        sbCount: (s.tabs || []).filter(t => t && (t.sb || t.scrollback)).length,
         v: s.v || 1,
         avgCtx: _avgCtx(s),
         viewMode: s.viewMode,
@@ -401,7 +555,13 @@ export async function restoreSnapshot(ts, shell) {
         if (id == null) continue;
         const rt = shell.tabs.get(id);
         if (!rt) continue;
-        const replay = (sav.scrollback || '').replace(/\n/g, '\r\n');
+        // v3 keeps the bytes in the blob store and the hash here; v1/v2 kept
+        // the text inline. Read from wherever this snapshot put it.
+        let saved = sav.sb ? await _getBlob(sav.sb) : (sav.scrollback || '');
+        // v3 bytes are raw PTY output and already carry their own CRLF; the old
+        // inline dumps were line-joined text that needs them added. Rewriting
+        // CRLF-terminated output would double every newline.
+        const replay = /\r\n/.test(saved) ? saved : saved.replace(/\n/g, '\r\n');
         rt.write(SANE + divider);
         if (replay) rt.write(replay + '\r\n');
         rt.write(SANE);
@@ -522,10 +682,15 @@ export async function openTimemachineModal(shell) {
             // Say up front what this row can actually do: a v1 snapshot has no
             // cwds, so it can only repaint tabs that still exist.
             const kind = r.cwdCount ? `${r.cwdCount} restorable` : 'view only';
+            // How much history this row actually holds. A snapshot that caught
+            // 3 of 22 tabs looked identical to one that caught all 22 until you
+            // restored it and found the other nineteen blank.
+            const hist = r.sbCount == null ? ''
+                : ` · ${r.sbCount}/${r.tabCount} with history`;
             row.innerHTML = `
                 <div class="soa-tm-when">
                     <strong>${_fmt(r.ts)}</strong>
-                    <span class="soa-tm-meta">${_ago(r.ts)} · ${r.tabCount} tab${r.tabCount === 1 ? '' : 's'} · ${kind} · ${r.viewMode || 'tabs'}${ctx}</span>
+                    <span class="soa-tm-meta">${_ago(r.ts)} · ${r.tabCount} tab${r.tabCount === 1 ? '' : 's'} · ${kind}${hist} · ${r.viewMode || 'tabs'}${ctx}</span>
                 </div>
                 <div class="soa-tm-row-actions">
                     <button class="soa-tm-restore" type="button">Restore</button>


### PR DESCRIPTION
**The pull tab.** It was there all along — 15px, vertically centred, and fully transparent at rest, so all you saw was a 3px hairline at half opacity. It is a small panel-coloured tab again with the chevron visible; the CTX label still waits for hover.

**Clipped prompts.** A prompt over ~7 lines was cut mid-word with no affordance and no way to read the rest. Every turn now opens to its full text — fade marks the cut, a toggle in the gutter goes through it, and the text is untouched so selecting a run of prompts still copies cleanly.

**The Time Machine**, which is the substantial one. Capture read the browser's xterm buffers, which miss the fleet three ways:

- a tab this window never activated has no buffer at all (bytes still queued for a first fit) — recorded as *no history*;
- the buffers that exist hold 1000 lines by design;
- `translateToString` drops every colour and escape before it is written down.

The daemon holds 256 KB of raw bytes per tab, for every tab, across its own restarts. Capture now asks it (`GET /api/scrollback`); the xterm dump is the fallback for when the daemon can't be reached.

To keep that affordable, scrollback moves into a content-addressed store keyed by hash — between two snapshots most tabs emitted nothing, so an unchanged tab costs a 16-byte string instead of a quarter megabyte. Orphaned blobs are collected on prune. Each row now reports how many tabs it actually captured history for.

v1/v2 snapshots keep their inline scrollback and still restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)